### PR TITLE
Improve scene options interface

### DIFF
--- a/src/renderer/components/SceneDetail.tsx
+++ b/src/renderer/components/SceneDetail.tsx
@@ -38,31 +38,42 @@ export default class SceneDetail extends React.Component {
     return (
       <div className='SceneDetail'>
         <div className="u-button-row">
+
+          <div className="u-abs-center">
+            {this.state.isEditingName && (
+              <form className="SceneNameForm" onSubmit={this.endEditingName.bind(this)}>
+                <input
+                  autoFocus
+                  type="text"
+                  ref={this.nameInputRef}
+                  value={this.props.scene.name}
+                  onBlur={this.endEditingName.bind(this)}
+                  onChange={this.onChangeName.bind(this)} />
+              </form>
+            )}
+            {!this.state.isEditingName && (
+              <h2
+                className="SceneName u-clickable"
+                onClick={this.beginEditingName.bind(this)}>{this.props.scene.name}</h2>
+            )}
+          </div>
+
           <div className="BackButton u-button u-clickable" onClick={this.props.goBack}>Back</div>
           <div
             className="DeleteButton u-destructive u-button u-clickable"
             onClick={this.props.onDelete.bind(this, this.props.scene)}>
             Delete
           </div>
+
+          <div className="u-button-row-right">
+            <div onClick={this.play.bind(this)} className="u-clickable u-button">
+              Play
+            </div>
+          </div>
         </div>
 
         <div className="SceneDetail__Content">
           <div className="SceneDetail__Options">
-            {this.state.isEditingName && (
-              <form className="SceneNameForm" onSubmit={this.endEditingName.bind(this)}>
-                <input
-                  type="text"
-                  ref={this.nameInputRef}
-                  value={this.props.scene.name}
-                  onChange={this.onChangeName.bind(this)} />
-              </form>
-            )}
-            {!this.state.isEditingName && (
-              <h1
-                className="SceneName u-clickable"
-                onClick={this.beginEditingName.bind(this)}>{this.props.scene.name}</h1>
-            )}
-
             <form className="SceneOptionsForm">
               <SimpleOptionPicker
                 onChange={this.onChangeTimingFunction.bind(this)}
@@ -116,10 +127,6 @@ export default class SceneDetail extends React.Component {
                   label="Hastebin ID"
                   value={this.props.scene.hastebinID} />
             </form>
-
-            <div onClick={this.play.bind(this)} className="SceneDetail__PlayButton u-clickable u-button">
-              Play
-            </div>
           </div>
 
           <div className='SceneDetail__Sources'>

--- a/src/renderer/components/SceneDetail.tsx
+++ b/src/renderer/components/SceneDetail.tsx
@@ -20,6 +20,30 @@ type Props = {
   onUpdateScene(scene: Scene, fn: (scene: Scene) => void): void,
 };
 
+class ControlGroup extends React.Component {
+  readonly props: {
+    title: string,
+    isNarrow: boolean,
+    children: React.ReactNode,
+  };
+
+  render() {
+    return (
+      <form
+          className={`ControlGroup ${this.props.isNarrow ? 'm-narrow' : 'm-wide'}`}
+          onSubmit={this.preventDefault.bind(this)}>
+        <div className="ControlGroup__Title">{this.props.title}</div>
+        {this.props.children}
+      </form>
+    );
+  }
+
+  preventDefault(e: Event) {
+    e.preventDefault();
+    return;
+  }
+}
+
 export default class SceneDetail extends React.Component {
   readonly props: Props;
   readonly nameInputRef: React.RefObject<HTMLInputElement> = React.createRef();
@@ -72,65 +96,8 @@ export default class SceneDetail extends React.Component {
           </div>
         </div>
 
-        <div className="SceneDetail__Content">
-          <div className="SceneDetail__Options">
-            <form className="SceneOptionsForm">
-              <SimpleOptionPicker
-                onChange={this.onChangeTimingFunction.bind(this)}
-                label="Timing"
-                value={this.props.scene.timingFunction}
-                keys={Object.values(TF)} />
-              {this.props.scene.timingFunction === TF.constant && (
-                <SimpleTextInput
-                  onChange={this.onChangeTimingConstant.bind(this)}
-                  label="Time between images (ms)"
-                  value={this.props.scene.timingConstant.toString()} />
-              )}
-              <SimpleOptionPicker
-                onChange={this.onChangeImageTypeFilter.bind(this)}
-                label="Image Filter"
-                value={this.props.scene.imageTypeFilter}
-                keys={Object.values(IF)} />
-              <SimpleOptionPicker
-                onChange={this.onChangeZoomType.bind(this)}
-                label="Zoom Type"
-                value={this.props.scene.zoomType}
-                keys={Object.values(ZF)} />
-              {this.props.scene.zoomType != ZF.none && (
-                <SimpleSliderInput
-                  onChange={this.onChangeZoomLevel.bind(this)}
-                  label={"Zoom Length: " + this.props.scene.zoomLevel + "s"}
-                  min={1}
-                  max={20}
-                  value={this.props.scene.zoomLevel.toString()} />
-              )}
-              <SimpleCheckbox
-                text="Cross-fade images"
-                isOn={this.props.scene.crossFade}
-                onChange={this.onChangeCrossFade.bind(this)} />
-              <SimpleOptionPicker
-                onChange={this.onChangeOverlaySceneID.bind(this)}
-                label="Overlay scene"
-                value={this.props.scene.overlaySceneID.toString()}
-                getLabel={this.getSceneName.bind(this)}
-                keys={["0"].concat(this.props.allScenes.map((s) => s.id.toString()))} />
-              {this.props.scene.overlaySceneID != 0 && (
-                <SimpleSliderInput
-                  onChange={this.onChangeOverlaySceneOpacity.bind(this)}
-                  label={"Overlay opacity: " + (this.props.scene.overlaySceneOpacity * 100).toFixed(0) + '%'}
-                  min={1}
-                  max={100}
-                  value={(this.props.scene.overlaySceneOpacity * 100).toString()} />
-              )}
-              <SimpleTextInput
-                  onChange={this.onChangeHastebinID.bind(this)}
-                  label="Hastebin ID"
-                  value={this.props.scene.hastebinID} />
-            </form>
-          </div>
-
-          <div className='SceneDetail__Sources'>
-            <h2>Sources:</h2>
+        <div className="SceneDetail__Content ControlGroupGroup">
+          <ControlGroup title="Sources" isNarrow={false}>
             <DirectoryPicker
               directories={this.props.scene.directories}
               onChange={this.onChangeDirectories.bind(this)}/>
@@ -138,7 +105,76 @@ export default class SceneDetail extends React.Component {
               directories={this.props.scene.directories}
               onChangeDirectories={this.onChangeDirectories.bind(this)}
               onChangeHastebinID={this.onChangeHastebinID.bind(this)}/>
-          </div>
+          </ControlGroup>
+        
+          <ControlGroup title="Timing" isNarrow={true}>
+            <SimpleOptionPicker
+              onChange={this.onChangeTimingFunction.bind(this)}
+              label="Timing"
+              value={this.props.scene.timingFunction}
+              keys={Object.values(TF)} />
+              <SimpleTextInput
+                isEnabled={this.props.scene.timingFunction === TF.constant}
+                onChange={this.onChangeTimingConstant.bind(this)}
+                label="Time between images (ms)"
+                value={this.props.scene.timingConstant.toString()} />
+          </ControlGroup>
+
+          <ControlGroup title="Effects" isNarrow={true}>
+
+            <SimpleCheckbox
+              text="Cross-fade images"
+              isOn={this.props.scene.crossFade}
+              onChange={this.onChangeCrossFade.bind(this)} />
+
+            <div className="ControlSubgroup">
+              <SimpleOptionPicker
+                onChange={this.onChangeZoomType.bind(this)}
+                label="Zoom Type"
+                value={this.props.scene.zoomType}
+                keys={Object.values(ZF)} />
+              <SimpleSliderInput
+                isEnabled={this.props.scene.zoomType != ZF.none}
+                onChange={this.onChangeZoomLevel.bind(this)}
+                label={"Zoom Length: " + this.props.scene.zoomLevel + "s"}
+                min={1}
+                max={20}
+                value={this.props.scene.zoomLevel.toString()} />
+            </div>
+
+            <div className="ControlSubgroup">
+              <SimpleOptionPicker
+                onChange={this.onChangeOverlaySceneID.bind(this)}
+                label="Overlay scene"
+                value={this.props.scene.overlaySceneID.toString()}
+                getLabel={this.getSceneName.bind(this)}
+                keys={["0"].concat(this.props.allScenes.map((s) => s.id.toString()))} />
+              <SimpleSliderInput
+                isEnabled={this.props.scene.overlaySceneID != 0}
+                onChange={this.onChangeOverlaySceneOpacity.bind(this)}
+                label={"Overlay opacity: " + (this.props.scene.overlaySceneOpacity * 100).toFixed(0) + '%'}
+                min={1}
+                max={100}
+                value={(this.props.scene.overlaySceneOpacity * 100).toString()} />
+            </div>
+          </ControlGroup>
+
+          <ControlGroup title="Images" isNarrow={true}>
+            <SimpleOptionPicker
+              onChange={this.onChangeImageTypeFilter.bind(this)}
+              label="Image Filter"
+              value={this.props.scene.imageTypeFilter}
+              keys={Object.values(IF)} />
+          </ControlGroup>
+
+          <ControlGroup title="Text" isNarrow={true}>
+            <SimpleTextInput
+              isEnabled={true}
+              onChange={this.onChangeHastebinID.bind(this)}
+              label="Hastebin ID"
+              value={this.props.scene.hastebinID} />
+          </ControlGroup>
+
         </div>
       </div>
     )

--- a/src/renderer/components/SimpleCheckbox.tsx
+++ b/src/renderer/components/SimpleCheckbox.tsx
@@ -10,11 +10,10 @@ export default class SimpleCheckbox extends React.Component {
   render() {
     return (
       <label className="SimpleCheckbox">
-        <input type="checkbox"
+        {this.props.text} <input type="checkbox"
           value={this.props.text}
           checked={this.props.isOn} 
-          onChange={this.onToggle.bind(this)}
-          /> {this.props.text}
+          onChange={this.onToggle.bind(this)} /> 
       </label>
     )
   }

--- a/src/renderer/components/SimpleSliderInput.tsx
+++ b/src/renderer/components/SimpleSliderInput.tsx
@@ -7,6 +7,7 @@ export default class SimpleSliderInput extends React.Component {
     min: number,
     max: number,
     value: string,
+    isEnabled: boolean,
     onChange: (value: string) => void
   };
 
@@ -15,6 +16,7 @@ export default class SimpleSliderInput extends React.Component {
       <div className="SimpleSliderInput">
         <label>{this.props.label}</label>
         <input
+          disabled={!this.props.isEnabled}
           type="range"
           min={this.props.min}
           max={this.props.max}

--- a/src/renderer/components/SimpleTextInput.tsx
+++ b/src/renderer/components/SimpleTextInput.tsx
@@ -5,6 +5,7 @@ export default class SimpleTextInput extends React.Component {
   readonly props: {
     label: string,
     value: string,
+    isEnabled: boolean,
     onChange: (value: string) => void
   };
 
@@ -14,6 +15,7 @@ export default class SimpleTextInput extends React.Component {
         <label>{this.props.label}</label>
         <input
           type="text"
+          disabled={!this.props.isEnabled}
           value={this.props.value}
           onChange={this.onChange.bind(this)}>
         </input>

--- a/src/renderer/components/URLImporter.tsx
+++ b/src/renderer/components/URLImporter.tsx
@@ -31,6 +31,7 @@ export default class URLImporter extends React.Component {
               </button>
             </Modal>
         )}
+        <div style={{clear: 'both'}}></div>
       </div>
     )
   }

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -72,6 +72,7 @@ a {
 .u-button-row {
   @include noselect;
 
+  position: relative;
   z-index: 1;
   padding: $smallPadding $smallPadding 0 $smallPadding;
   height: $buttonBarHeight;
@@ -79,6 +80,11 @@ a {
 
   .u-button-row-right {
     float: right;
+
+    .u-button {
+      margin-right: 0;
+      margin-left: $smallPadding;
+    }
   }
 
   .u-button {
@@ -115,6 +121,16 @@ a {
   filter: blur(8px);
   -webkit-filter: blur(8px);
   transform: scale(2, 2);
+}
+
+.u-abs-center {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  z-index: -1;
 }
 
 /* attributes */
@@ -199,6 +215,28 @@ a {
   }
 }
 
+.SceneDetail {
+  .SceneName {
+    display: inline-block;
+    margin-top: 0;
+    color: $black !important;
+    line-height: $buttonBarHeight;
+  }
+
+  .SceneNameForm {
+    display: inline-block;
+    width: 200px;
+
+    input[type=text] {
+      font-size: 21px;
+      font-weight: 700;
+      display: block;
+      width: 100%;
+      margin-top: 4px;
+    }
+  }
+}
+
 .SceneDetail__Content {
   position: fixed;
   top: $buttonBarHeight;
@@ -206,44 +244,15 @@ a {
   bottom: 0;
   left: 0;
   padding: $smallPadding;
-
-  h1:first-child {
-    margin-top: 0;
-    color: $bodyColor;
-  }
-
-  input[type=text] {
-    font-size: 28px;
-    font-weight: 700;
-    display: block;
-    width: 100%;
-    margin-bottom: 13px;
-  }
+  overflow: auto;
 
   form {
     margin-bottom: $smallPadding;
   }
 }
 
-$sceneDetailOptionsWidth: 220px;
-
-.SceneDetail__Options {
-  position: absolute;
-  width: $sceneDetailOptionsWidth;
-  padding: $smallPadding;
-  top: 0; left: $smallPadding; bottom: 0;
-  overflow: hidden;
-  .SimpleOptionPicker select {
-    max-width: 210px;
-  }
-}
-
-.SceneDetail__Sources {
-  position: absolute;
-  left: $sceneDetailOptionsWidth;
-  top: 0; right: 0; bottom: 0;
-  overflow: auto;
-  padding-left: $smallPadding * 2;
+.SimpleOptionPicker select {
+  max-width: 210px;
 }
 
 .SceneDetail__PlayButton {

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -6,6 +6,7 @@ $white: white;
 $yellow: #ffeeb1;
 $buttonBarColorTop: #ffeeb1;
 $buttonBarColorBottom: #ffcd09;
+$uiGray: #d8d8d8;
 $bodyColor: white;
 $buttonTop: #eaeaea;
 $buttonBottom: #dcdcdc;
@@ -215,6 +216,82 @@ a {
   }
 }
 
+.ControlGroupGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  align-content: flex-start;
+}
+
+.ControlGroup {
+  flex-grow: 1;
+
+  margin-top: 1em;
+  margin-bottom: $smallPadding * 3;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+
+  border: 1px solid $black;
+  padding: ($smallPadding * 3) $smallPadding $smallPadding $smallPadding;
+  position: relative;
+
+  color: $black;
+  background-color: $uiGray;
+
+  &.m-narrow {
+    width: 300px;
+  }
+
+  &.m-wide {
+    width: 100%;
+  }
+
+  .ControlGroup__Title {
+    position: absolute;
+    top: -0.7em;
+    height: 0.7em;
+    overflow: visible;
+    padding: 0 0.2rem;
+    font-weight: bold;
+    font-size: 1rem;
+    background-color: $uiGray;
+    border-top: 1px solid $black;
+    border-right: 1px solid $black;
+    border-left: 1px solid $black;
+  }
+}
+
+.ControlSubgroup {
+  flex-grow: 1;
+
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  align-content: flex-start;
+
+  & > * {
+    margin-right: $smallPadding * 2;
+  }
+}
+
+@mixin control {
+  margin-bottom: $smallPadding * 2;
+  label {
+    display: block;
+    margin-bottom: $smallPadding;
+  }
+}
+
+.SimpleOptionPicker, .SimpleTextInput, .SimpleSliderInput, .SimpleCheckbox {
+  @include control;
+}
+
+.SimpleOptionPicker {
+  select {
+    max-width: 210px;
+  }
+}
+
 .SceneDetail {
   .SceneName {
     display: inline-block;
@@ -245,14 +322,6 @@ a {
   left: 0;
   padding: $smallPadding;
   overflow: auto;
-
-  form {
-    margin-bottom: $smallPadding;
-  }
-}
-
-.SimpleOptionPicker select {
-  max-width: 210px;
 }
 
 .SceneDetail__PlayButton {


### PR DESCRIPTION
Now that we have a lot of fields, the UI was getting pretty hard to visually parse. Here's what it looks like now:

<img width="894" alt="screenshot 2018-12-26 11 39 58" src="https://user-images.githubusercontent.com/33943477/50455520-565d0780-0903-11e9-8412-c1a4e0820d59.png">

I've taken most of my UI inspiration from [BeOS/Haiku](https://www.haiku-os.org). An arbitrary choice, but it does make things easier to have a source.