### PR TITLE
Animated GIF Detection fix

### DIFF
--- a/src/renderer/components/player/HeadlessScenePlayer.tsx
+++ b/src/renderer/components/player/HeadlessScenePlayer.tsx
@@ -13,7 +13,7 @@ import CaptionProgram from './CaptionProgram';
 import { TK, IF } from '../../const';
 
 function isImage(path: string): boolean {
-  const p = path.toLowerCase()
+  const p = path.toLowerCase();
   if (p.endsWith('.gif')) return true;
   if (p.endsWith('.png')) return true;
   if (p.endsWith('.jpeg')) return true;
@@ -33,7 +33,7 @@ function filterPathsToJustImages(imageTypeFilter: string, paths: Array<string>):
       return paths.filter((f) => f.toLowerCase().endsWith('.gif'));
     case IF.stills:
       return paths.filter((f) => {
-        const p = f.toLowerCase()
+        const p = f.toLowerCase();
         // if (p.endsWith('.gif') && !animated(fs.readFileSync(f))) return true;
         if (p.endsWith('.gif')) return false;
         if (p.endsWith('.png')) return true;
@@ -114,7 +114,6 @@ class CancelablePromise extends Promise<Array<string>> {
   cancel() {
     this.hasCanceled_ = true;
   }
-
 }
 
 export default class HeadlessScenePlayer extends React.Component {
@@ -196,18 +195,18 @@ export default class HeadlessScenePlayer extends React.Component {
     this.setState({allURLs: []});
     let newAllURLs = Array<Array<string>>();
 
-    function directoryLoop(e : HeadlessScenePlayer) {
-      let d = e.props.scene.directories[n];
+    let directoryLoop = () => {
+      let d = this.props.scene.directories[n];
       let loadPromise = (isURL(d)
-          ? loadRemoteImageURLList(d, e.props.scene.imageTypeFilter)
-          : loadLocalDirectory(d, e.props.scene.imageTypeFilter));
+          ? loadRemoteImageURLList(d, this.props.scene.imageTypeFilter)
+          : loadLocalDirectory(d, this.props.scene.imageTypeFilter));
 
       let message = d;
-      if (e.props.historyOffset == -1) {
+      if (this.props.historyOffset == -1) {
         message = "<p>Loading Overlay...</p>" + d;
       }
 
-      e.setState({promise: loadPromise, progressMessage: message});
+      this.setState({promise: loadPromise, progressMessage: message});
 
       loadPromise
         .getPromise()
@@ -216,7 +215,7 @@ export default class HeadlessScenePlayer extends React.Component {
 
           // The scene can configure which of these branches to take
           if (urls.length > 0) {
-            if (e.props.scene.weightDirectoriesEqually) {
+            if (this.props.scene.weightDirectoriesEqually) {
               // Just add the new urls to the end of the list
               newAllURLs = newAllURLs.concat([urls]);
             } else {
@@ -226,17 +225,19 @@ export default class HeadlessScenePlayer extends React.Component {
             }
           }
 
-          if (n < e.props.scene.directories.length) {
-            e.setState({directoriesProcessed: (n + 1)});
-            directoryLoop(e);
+          if (n < this.props.scene.directories.length) {
+            this.setState({directoriesProcessed: (n + 1)});
+            directoryLoop();
           } else {
-            e.setState({allURLs: newAllURLs, isLoaded: true});
-            setTimeout(e.props.didFinishLoading, 0);
+            this.setState({allURLs: newAllURLs, isLoaded: true});
+            setTimeout(this.props.didFinishLoading, 0);
           }
-        })
-    }
+        }
+      )
+    };
 
-    directoryLoop(this);
+    directoryLoop();
+
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/player/HeadlessScenePlayer.tsx
+++ b/src/renderer/components/player/HeadlessScenePlayer.tsx
@@ -3,7 +3,6 @@ import * as ReactDOM from 'react-dom';
 import recursiveReaddir from 'recursive-readdir';
 import fs from 'fs'
 import fileURL from 'file-url';
-// import animated from 'animated-gif-detector';
 import wretch from 'wretch';
 
 import Scene from '../../Scene';
@@ -27,23 +26,10 @@ function isImage(path: string): boolean {
 function filterPathsToJustImages(imageTypeFilter: string, paths: Array<string>): Array<string> {
   switch (imageTypeFilter) {
     case IF.any:
+    case IF.stills:
       return paths.filter((p) => isImage(p));
     case IF.gifs:
-      // return paths.filter((f) => f.toLowerCase().endsWith('.gif') && animated(fs.readFileSync(f)));
       return paths.filter((f) => f.toLowerCase().endsWith('.gif'));
-    case IF.stills:
-      return paths.filter((f) => {
-        const p = f.toLowerCase();
-        // if (p.endsWith('.gif') && !animated(fs.readFileSync(f))) return true;
-        if (p.endsWith('.gif')) return false;
-        if (p.endsWith('.png')) return true;
-        if (p.endsWith('.jpeg')) return true;
-        if (p.endsWith('.jpg')) return true;
-        if (p.endsWith('.webp')) return true;
-        if (p.endsWith('.tiff')) return true;
-        if (p.endsWith('.svg')) return true;
-        return false;
-      });
     default:
       console.warn('unknown image type filter', imageTypeFilter);
       return paths.filter((p) => isImage(p));
@@ -167,6 +153,7 @@ export default class HeadlessScenePlayer extends React.Component {
             timingConstant={this.props.scene.timingConstant}
             zoomType={this.props.scene.zoomType}
             zoomLevel={this.props.scene.zoomLevel}
+            imageTypeFilter={this.props.scene.imageTypeFilter}
             isPlaying={this.props.isPlaying}
             fadeEnabled={this.props.scene.crossFade}
             imageSizeMin={this.props.scene.imageSizeMin}

--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import ImageView from './ImageView';
 import TIMING_FUNCTIONS from '../../TIMING_FUNCTIONS';
-import {TF, ZF} from '../../const';
+import {IF, TF, ZF} from '../../const';
+import fs from "fs";
+import animated from 'animated-gif-detector';
 
 function choice<T>(items: Array<T>): T {
   const i = Math.floor(Math.random() * items.length);
@@ -20,11 +22,12 @@ export default class ImagePlayer extends React.Component {
     timingConstant: string,
     zoomType: string,
     zoomLevel: number,
+    imageTypeFilter: string,
     historyOffset: number,
     fadeEnabled: boolean,
     imageSizeMin: number,
     setHistoryLength: (historyLength: number) => void,
-  }
+  };
 
   readonly state = {
     numBeingLoaded: 0,
@@ -33,7 +36,7 @@ export default class ImagePlayer extends React.Component {
     historyPaths: Array<string>(),
     timeToNextFrame: 0,
     timeoutID: 0,
-  }
+  };
 
   _isMounted = false;
 
@@ -166,6 +169,17 @@ export default class ImagePlayer extends React.Component {
     img.onerror = () => {
       setTimeout(errorCallback, 0);
     };
+
+    // Filter gifs by animation
+    if (url.toLocaleLowerCase().endsWith('.gif')) {
+      // Exclude non-animated gifs from gifs
+      if (this.props.imageTypeFilter == IF.gifs && !animated(fs.readFileSync(url.replace("file:///", "")))) {
+        return;
+      // Exclude animated gifs from stills
+      } else if (this.props.imageTypeFilter == IF.stills && animated(fs.readFileSync(url.replace("file:///", "")))) {
+        return;
+      }
+    }
 
     img.src = url;
   }


### PR DESCRIPTION
So, running the animated-gif detection when we're initializing the URL list just takes too long and results in unmanageable load times for large sets.

Instead, running a check over gifs when the image source is loaded impacts performance much less and is hardly even noticed by the user. If the user selects a _very_ fast transition time, they may notice a slight delay... but on the order of milliseconds.

Cleaned up my code a little