### PR TITLE
Use gif-info instead of animated-gif-detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "animated-gif-detector": "^1.2.0",
     "file-url": "^2.0.2",
+    "gif-info": "^1.0.1",
     "lodash": "^4.17.11",
     "progressbar.js": "^1.0.1",
     "react": "^16.6.3",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -21,5 +21,5 @@ declare module '*.icns' {
 
 declare module 'file-url';
 declare module 'recursive-readdir';
-declare module 'animated-gif-detector';
+declare module 'gif-info';
 declare module 'progressbar.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,13 +234,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-animated-gif-detector@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/animated-gif-detector/-/animated-gif-detector-1.2.0.tgz#cb2f9911ca8024f2b34c693b7fd64542ee416189"
-  integrity sha1-yy+ZEcqAJPKzTGk7f9ZFQu5BYYk=
-  dependencies:
-    inherits "^2.0.1"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1772,6 +1765,11 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+gif-info@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gif-info/-/gif-info-1.0.1.tgz#003765fc0c4c65a8de64d5568c1e8ead309d09dc"
+  integrity sha1-ADdl/AxMZajeZNVWjB6OrTCdCdw=
 
 glob-parent@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
So, since we could potentially use the duration of animated gifs, I found an alternative to `animated-gif-detector` which does both (and more... and faster! 👍): https://github.com/Prinzhorn/gif-info

I implemented gif-info and included a snippet to store the duration, though I'm not actually doing anything with that variable yet.