### PR TITLE
Add ContextMenu with image information

### DIFF
--- a/src/renderer/components/player/HeadlessScenePlayer.tsx
+++ b/src/renderer/components/player/HeadlessScenePlayer.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import recursiveReaddir from 'recursive-readdir';
-import fs from 'fs'
 import fileURL from 'file-url';
 import wretch from 'wretch';
 
@@ -191,7 +189,7 @@ export default class HeadlessScenePlayer extends React.Component {
           : loadLocalDirectory(d, this.props.scene.imageTypeFilter));
 
       let message = d;
-      if (this.props.historyOffset == -1) {
+      if (this.props.opacity != 1) {
         message = "<p>Loading Overlay...</p>" + d;
       }
 

--- a/src/renderer/components/player/ImageContextMenu.tsx
+++ b/src/renderer/components/player/ImageContextMenu.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import {remote} from 'electron';
+import fs from "fs";
+
+export default class ImageContextMenu extends React.Component {
+  readonly root: React.RefObject<HTMLImageElement> = React.createRef();
+  readonly props: {
+    fileURL: string,
+  };
+  readonly state = {
+    visible: false,
+  };
+
+  componentDidMount() {
+    document.addEventListener('contextmenu', this._handleContextMenu);
+    document.addEventListener('click', this._handleClick);
+    document.addEventListener('scroll', this._handleScroll);
+  };
+
+  componentWillUnmount() {
+    document.removeEventListener('contextmenu', this._handleContextMenu);
+    document.removeEventListener('click', this._handleClick);
+    document.removeEventListener('scroll', this._handleScroll);
+  }
+
+  _handleContextMenu = (event : MouseEvent) => {
+    event.preventDefault();
+
+    this.setState({ visible: true });
+
+    const clickX = event.clientX;
+    const clickY = event.clientY;
+    const screenW = window.innerWidth;
+    const screenH = window.innerHeight;
+    const rootW = this.root.current.offsetWidth;
+    const rootH = this.root.current.offsetHeight;
+
+    const right = (screenW - clickX) > rootW;
+    const left = !right;
+    const top = (screenH - clickY) > rootH;
+    const bottom = !top;
+
+    if (right) {
+      this.root.current.style.left = `${clickX + 5}px`;
+    }
+
+    if (left) {
+      this.root.current.style.left = `${clickX - rootW - 5}px`;
+    }
+
+    if (top) {
+      this.root.current.style.top = `${clickY + 5}px`;
+    }
+
+    if (bottom) {
+      this.root.current.style.top = `${clickY - rootH - 5}px`;
+    }
+  };
+
+  _handleClick = (event : MouseEvent) => {
+    const { visible } = this.state;
+    const wasOutside = !(event.target.contains === this.root);
+
+    if (wasOutside && visible) this.setState({ visible: false, });
+  };
+
+  _handleScroll = () => {
+    const { visible } = this.state;
+
+    if (visible) this.setState({ visible: false, });
+  };
+
+  copy = () => {
+    navigator.clipboard.writeText(this.props.fileURL.replace("file:///", ""));
+  };
+
+  showInFolder = () => {
+    remote.shell.showItemInFolder(this.props.fileURL);
+  };
+
+  open = () => {
+    remote.shell.openItem(this.props.fileURL);
+  };
+
+  delete = () => {
+    let fileURL = this.props.fileURL.replace("file:///", "");
+    if (confirm("Are you sure you want to delete " + fileURL + "?")) {
+      if (fs.existsSync(fileURL)) {
+        fs.unlink(fileURL, (err) => {
+          if (err) {
+            alert("An error ocurred while deleting the file: " + err.message);
+            console.log(err);
+            return;
+          }
+        });
+      } else {
+        alert("This file doesn't exist, cannot delete");
+      }
+    } else {
+      // Do nothing
+    }
+  };
+
+  render() {
+    const isFile = this.props.fileURL.includes('file:///');
+    let display = this.props.fileURL;
+    if (isFile) {
+      display = display.replace("file:///", "");
+    }
+
+    return(this.state.visible || null) &&
+        <div ref={this.root} className="ContextMenu">
+          <div className="ContextMenu--option" onClick={this.copy.bind(this)}>{display}</div>
+          <div className="ContextMenu--option" onClick={this.open.bind(this)}>Open</div>
+          {isFile && (
+            <div>
+              <div className="ContextMenu--separator" />
+              <div className="ContextMenu--option" onClick={this.showInFolder.bind(this)}>Show In Folder</div>
+              <div className="ContextMenu--option" onClick={this.delete.bind(this)}>Delete</div>
+            </div>
+          )}
+          {/* Predefined classes for ContextMenu
+          <div className="ContextMenu--option"/>
+          <div className="ContextMenu--option ContextMenu--option__disabled"/>
+          <div className="ContextMenu--separator" />*/}
+        </div>
+  };
+}

--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -48,14 +48,14 @@ export default class ImagePlayer extends React.Component {
     const imgs = Array<HTMLImageElement>();
 
     // if user is browsing history, use that image instead
-    if (this.state.historyPaths.length > 0 && !this.props.isPlaying && this.props.historyOffset < 0) {
+    if (this.state.historyPaths.length > 0 && !this.props.isPlaying) {
       let offset = this.props.historyOffset;
       // if user went too far off the end, just loop to the front again
       while (offset < -this.state.historyPaths.length) {
         offset += this.state.historyPaths.length;
       }
       const img = new Image();
-      img.src = this.state.historyPaths[this.state.historyPaths.length + offset];
+      img.src = this.state.historyPaths[(this.state.historyPaths.length - 1) + offset];
       imgs.push(img);
     } else {
       const max = this.props.fadeEnabled ? 3 : 2;
@@ -113,7 +113,8 @@ export default class ImagePlayer extends React.Component {
             img={img}
             key={img.src}
             fadeState={this.props.fadeEnabled ? (img.src === imgs[0].src ? 'in' : 'out') : 'none'}
-            fadeDuration={this.state.timeToNextFrame / 2} />;
+            fadeDuration={this.state.timeToNextFrame / 2}
+            fileURL={this.state.historyPaths[(this.state.historyPaths.length - 1) + this.props.historyOffset]}/>;
         })}
       </div>
     );

--- a/src/renderer/components/player/ImageView.tsx
+++ b/src/renderer/components/player/ImageView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import ImageContextMenu from "./ImageContextMenu";
 
 
 const maxFadeSeconds = 5;
@@ -8,11 +8,12 @@ const maxFadeSeconds = 5;
 export default class ImageView extends React.Component {
   readonly props: {
     img: HTMLImageElement,
+    fileURL: string,
     fadeState: string,
     fadeDuration: number,
-  }
+  };
 
-  readonly contentRef: React.RefObject<HTMLImageElement> = React.createRef()
+  readonly contentRef: React.RefObject<HTMLImageElement> = React.createRef();
 
   componentDidMount() {
     this._applyImage();
@@ -79,6 +80,9 @@ export default class ImageView extends React.Component {
       <div
         className="ImageView u-fill-container"
         style={style}
-        ref={this.contentRef} />);
+        ref={this.contentRef}>
+        <ImageContextMenu
+          fileURL={this.props.fileURL}/>
+      </div>);
   }
 }

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { remote } from 'electron';
 const { Menu, app } = remote;
 import Sound from 'react-sound';
@@ -22,7 +21,7 @@ export default class Player extends React.Component {
     goBack(): void,
     scene: Scene,
     overlayScene?: Scene,
-  }
+  };
 
   readonly state = {
     isMainLoaded: false,
@@ -30,10 +29,10 @@ export default class Player extends React.Component {
     isPlaying: false,
     historyOffset: 0,
     historyLength: 0,
-  }
+  };
 
   render() {
-    const canGoBack = this.state.historyOffset > -this.state.historyLength;
+    const canGoBack = this.state.historyOffset > -(this.state.historyLength-1);
     const canGoForward = this.state.historyOffset < 0;
     const audioPlayStatus = this.state.isPlaying
       ? (Sound as any).status.PLAYING
@@ -57,7 +56,7 @@ export default class Player extends React.Component {
           <HeadlessScenePlayer
             opacity={this.props.scene.overlaySceneOpacity}
             scene={this.props.overlayScene}
-            historyOffset={-1}
+            historyOffset={0}
             isPlaying={this.state.isPlaying}
             showLoadingState={showOverlayIndicator}
             showEmptyState={false}
@@ -192,12 +191,15 @@ export default class Player extends React.Component {
   historyBack() {
     this.setState({
       isPlaying: false,
-      historyOffset: this.state.historyOffset == 0 ? -2 : this.state.historyOffset - 1,
+      historyOffset: this.state.historyOffset - 1,
     });
   }
 
   historyForward() {
-    this.setState({isPlaying: false, historyOffset: Math.min(-1, this.state.historyOffset + 1)});
+    this.setState({
+      isPlaying: false,
+      historyOffset: this.state.historyOffset + 1,
+    });
   }
 
   navigateBack() {

--- a/src/renderer/components/sceneDetail/SceneDetail.tsx
+++ b/src/renderer/components/sceneDetail/SceneDetail.tsx
@@ -171,7 +171,7 @@ export default class SceneDetail extends React.Component {
                 onChange={this.onChangeOverlaySceneOpacity.bind(this)}
                 label={"Overlay opacity: " + (this.props.scene.overlaySceneOpacity * 100).toFixed(0) + '%'}
                 min={1}
-                max={100}
+                max={99}
                 value={(this.props.scene.overlaySceneOpacity * 100).toString()} />
             </div>
           </ControlGroup>

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -604,6 +604,41 @@ label.SimpleCheckbox {
   }
 }
 
+.ContextMenu {
+  position: fixed;
+  background: white;
+  box-shadow: 0px 2px 10px #999999;
+
+  &--option {
+    color: $black;
+    padding: 6px 8px 5px 8px;
+    min-width: 160px;
+    cursor: default;
+    font-size: 12px;
+    &:hover {
+      background: linear-gradient(to top, #555, #333);
+      color: white;
+    }
+
+    &:active {
+      color: #e9e9e9;
+      background: linear-gradient(to top, #555, #444);
+    }
+
+    &__disabled {
+      color: #999999;
+      pointer-events: none;
+    }
+  }
+
+  &--separator {
+    width: 100%;
+    height: 1px;
+    background: #CCCCCC;
+    margin: 0 0 0 0;
+  }
+}
+
 .CaptionProgram {
   z-index: 1;
   pointer-events: none;


### PR DESCRIPTION
This PR addresses #42 

Added a ContextMenu object and customized specifically for image information
When right clicking an image in the player it will _always_ display a link to the image (which when clicked copies the link to the clipboard) and an "Open" option which opens the link.
If the link is to a file, it will also display "Show in Folder" and "Delete" options. "Delete" will confirm the user wants to delete the file before actually deleting.

`historyOffset` and `historyPaths` logic was fixed