### PR TITLE
Add option to play full GIF animation

### DIFF
--- a/src/renderer/Scene.tsx
+++ b/src/renderer/Scene.tsx
@@ -1,17 +1,18 @@
 import {ZF, HTF, VTF, TF, IF, TK} from './const';
 
 export default class Scene {
-  id: number = 0
-  name: string = "Unnamed scene"
-  directories: Array<string> = []
-  timingFunction = TF.constant
+  id: number = 0;
+  name: string = "Unnamed scene";
+  directories: Array<string> = [];
+  timingFunction = TF.constant;
   timingConstant = "1000";
-  imageTypeFilter = IF.any
-  zoomType = ZF.none
-  effectLevel: number = 5
-  horizTransType = HTF.none
-  vertTransType = VTF.none
-  crossFade = false
+  imageTypeFilter = IF.any;
+  zoomType = ZF.none;
+  effectLevel: number = 5;
+  horizTransType = HTF.none;
+  vertTransType = VTF.none;
+  crossFade = false;
+  playFullGif = false;
   textKind: string = "";
   textSource: string = "";
   imageSizeMin: 200;
@@ -26,7 +27,7 @@ export default class Scene {
   // of it.
   // if false, the display chooses an image out of all possible images, without
   // looking at which directory it was in.
-  weightDirectoriesEqually = true
+  weightDirectoriesEqually = true;
 
   constructor(init?:Partial<Scene>) {
     Object.assign(this, init);

--- a/src/renderer/components/player/HeadlessScenePlayer.tsx
+++ b/src/renderer/components/player/HeadlessScenePlayer.tsx
@@ -156,6 +156,7 @@ export default class HeadlessScenePlayer extends React.Component {
             imageTypeFilter={this.props.scene.imageTypeFilter}
             isPlaying={this.props.isPlaying}
             fadeEnabled={this.props.scene.crossFade}
+            playFullGif={this.props.scene.playFullGif}
             imageSizeMin={this.props.scene.imageSizeMin}
             allURLs={this.state.allURLs} />)}
 

--- a/src/renderer/components/sceneDetail/SceneDetail.tsx
+++ b/src/renderer/components/sceneDetail/SceneDetail.tsx
@@ -177,11 +177,17 @@ export default class SceneDetail extends React.Component {
           </ControlGroup>
 
           <ControlGroup title="Images" isNarrow={true}>
-            <SimpleOptionPicker
-              onChange={this.onChangeImageTypeFilter.bind(this)}
-              label="Image Filter"
-              value={this.props.scene.imageTypeFilter}
-              keys={Object.values(IF)} />
+            <div className="ControlSubgroup">
+              <SimpleOptionPicker
+                onChange={this.onChangeImageTypeFilter.bind(this)}
+                label="Image Filter"
+                value={this.props.scene.imageTypeFilter}
+                keys={Object.values(IF)} />
+              <SimpleCheckbox
+                  text="Play Full GIF animations"
+                  isOn={this.props.scene.playFullGif}
+                  onChange={this.onChangePlayFullGif.bind(this)} />
+            </div>
           </ControlGroup>
 
           <ControlGroup title="Text" isNarrow={true}>
@@ -283,6 +289,8 @@ export default class SceneDetail extends React.Component {
   onChangeTimingConstant(constant: string) { this.update((s) => { s.timingConstant = constant; }); }
 
   onChangeCrossFade(value: boolean) { this.update((s) => { s.crossFade = value; }); }
+
+  onChangePlayFullGif(value: boolean) { this.update((s) => { s.playFullGif = value; }); }
 
   onChangeAudioURL(value: string) { this.update((s) => { s.audioURL = value; }); }
 };


### PR DESCRIPTION
This addresses #50 

Added a new option to scene which indicates if full gif animations should play. This only effects GIFs (obviously) and only changes the timing settings if timeout was _less_ than animation time for gif. E.g. If constant time is set to 5 seconds, any gifs that take longer than 5s to animate will extend timeout, otherwise, timeout will be 5s.

Because of the way images are processed, it is necessary to associate the currently displayed image with the timeout. Therefore, it was easiest to attach this data to the `Image` object itself. I co-opted the `alt` field for this purpose, but this data could be relocated later if necessary.