### PR TITLE
Improve fullscreen & add SceneOption Sidebar

### DIFF
--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -1,6 +1,4 @@
-import _ from 'lodash';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import {writeFileSync, mkdirSync, readFileSync, readFile} from 'fs';
 import path from 'path';
@@ -13,8 +11,8 @@ import Player from './player/Player';
 import {remote} from 'electron';
 
 class Route {
-  kind: string
-  value: any
+  kind: string;
+  value: any;
 
   constructor(init?:Partial<Route>) {
     Object.assign(this, init);
@@ -25,7 +23,7 @@ let initialState = {
   scenes: Array<Scene>(),
   route: Array<Route>(),
   autoEdit: false,
-}
+};
 
 const saveDir = path.join(remote.app.getPath('appData'), 'flipflip');
 try {
@@ -42,14 +40,14 @@ try {
     autoEdit: data.autoEdit,
     scenes: data.scenes.map((s: any) => new Scene(s)),
     route: data.route.map((s: any) => new Route(s)),
-  }
+  };
   console.log(initialState);
 } catch (e) {
   // who cares
 }
 
 export default class Meta extends React.Component {
-  readonly state = initialState
+  readonly state = initialState;
 
   isRoute(kind: string): Boolean {
     if (this.state.route.length < 1) return false;
@@ -99,6 +97,7 @@ export default class Meta extends React.Component {
         {this.isRoute('play') && (
           <Player
             scene={this.scene()}
+            onUpdateScene={this.onUpdateScene.bind(this)}
             overlayScene={this.overlayScene()}
             goBack={this.goBack.bind(this)} />
         )}

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -156,6 +156,7 @@ export default class Player extends React.Component {
 
   componentWillUnmount() {
     Menu.setApplicationMenu(originalMenu);
+    remote.getCurrentWindow().setFullScreen(false);
   }
 
   nop() {
@@ -213,5 +214,12 @@ export default class Player extends React.Component {
   toggleFullscreen() {
     const window = remote.getCurrentWindow();
     window.setFullScreen(!window.isFullScreen());
+    if (Menu.getApplicationMenu() == null) {
+      // Reattach menu
+      this.componentDidMount();
+    } else {
+      // Remove menu
+      Menu.setApplicationMenu(null);
+    }
   }
 };

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -5,6 +5,12 @@ import Sound from 'react-sound';
 
 import Scene from '../../Scene';
 import HeadlessScenePlayer from './HeadlessScenePlayer';
+import SimpleOptionPicker from "../ui/SimpleOptionPicker";
+import {HTF, TF, VTF, ZF} from "../../const";
+import SimpleTextInput from "../ui/SimpleTextInput";
+import SimpleCheckbox from "../ui/SimpleCheckbox";
+import SimpleSliderInput from "../ui/SimpleSliderInput";
+import ControlGroup from "../sceneDetail/ControlGroup";
 
 const keyMap = {
   playPause: ['Play/Pause', 'space'],
@@ -20,6 +26,7 @@ export default class Player extends React.Component {
   readonly props: {
     goBack(): void,
     scene: Scene,
+    onUpdateScene(scene: Scene, fn: (scene: Scene) => void): void,
     overlayScene?: Scene,
   };
 
@@ -105,6 +112,54 @@ export default class Player extends React.Component {
             </div>
           </div>
           <div className="BackButton u-button u-clickable" onClick={this.props.goBack}>Back</div>
+        </div>
+
+        <div className={`u-button-sidebar ${this.state.isPlaying ? 'u-show-on-hover-only' : 'u-hidden'}`}>
+          <h2 className="SceneOptions">Scene Options</h2>
+          <ControlGroup title="Timing" isNarrow={true}>
+            <SimpleOptionPicker
+                onChange={this.onChangeTimingFunction.bind(this)}
+                label="Timing"
+                value={this.props.scene.timingFunction}
+                keys={Object.values(TF)} />
+            <SimpleTextInput
+                isEnabled={this.props.scene.timingFunction === TF.constant}
+                onChange={this.onChangeTimingConstant.bind(this)}
+                label="Time between images (ms)"
+                value={this.props.scene.timingConstant.toString()} />
+          </ControlGroup>
+
+          <ControlGroup title="Effects" isNarrow={true}>
+            <SimpleCheckbox
+                text="Cross-fade images"
+                isOn={this.props.scene.crossFade}
+                onChange={this.onChangeCrossFade.bind(this)} />
+
+            <div className="ControlSubgroup">
+              <SimpleOptionPicker
+                  onChange={this.onChangeZoomType.bind(this)}
+                  label="Zoom Type"
+                  value={this.props.scene.zoomType}
+                  keys={Object.values(ZF)} />
+              <SimpleSliderInput
+                  isEnabled={true}
+                  onChange={this.onChangeEffectLevel.bind(this)}
+                  label={"Effect Length: " + this.props.scene.effectLevel + "s"}
+                  min={1}
+                  max={20}
+                  value={this.props.scene.effectLevel.toString()} />
+              <SimpleOptionPicker
+                  onChange={this.onChangeHorizTransType.bind(this)}
+                  label="Translate Horizontally"
+                  value={this.props.scene.horizTransType}
+                  keys={Object.values(HTF)} />
+              <SimpleOptionPicker
+                  onChange={this.onChangeVertTransType.bind(this)}
+                  label="Translate Vertically"
+                  value={this.props.scene.vertTransType}
+                  keys={Object.values(VTF)} />
+            </div>
+          </ControlGroup>
         </div>
       </div>
     );
@@ -222,4 +277,22 @@ export default class Player extends React.Component {
       Menu.setApplicationMenu(null);
     }
   }
+
+  update(fn: (scene: Scene) => void) {
+    this.props.onUpdateScene(this.props.scene, fn);
+  }
+
+  onChangeTimingFunction(fnId: string) { this.update((s) => { s.timingFunction = fnId; }); }
+
+  onChangeTimingConstant(constant: string) { this.update((s) => { s.timingConstant = constant; }); }
+
+  onChangeCrossFade(value: boolean) { this.update((s) => { s.crossFade = value; }); }
+
+  onChangeZoomType(type: string) { this.update((s) => { s.zoomType = type; }); }
+
+  onChangeEffectLevel(level: number) { this.update((s) => { s.effectLevel = level; }); }
+
+  onChangeHorizTransType(type: string) { this.update((s) => { s.horizTransType = type; }); }
+
+  onChangeVertTransType(type: string) { this.update((s) => { s.vertTransType = type; }); }
 };

--- a/src/renderer/components/sceneDetail/ControlGroup.tsx
+++ b/src/renderer/components/sceneDetail/ControlGroup.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+export default class ControlGroup extends React.Component {
+  readonly props: {
+    title: string,
+    isNarrow: boolean,
+    children: React.ReactNode,
+  };
+
+  render() {
+    return (
+        <form
+            className={`ControlGroup ${this.props.isNarrow ? 'm-narrow' : 'm-wide'}`}
+            onSubmit={this.preventDefault.bind(this)}>
+          <div className="ControlGroup__Title">{this.props.title}</div>
+          {this.props.children}
+        </form>
+    );
+  }
+
+  preventDefault(e: Event) {
+    e.preventDefault();
+    return;
+  }
+}

--- a/src/renderer/components/sceneDetail/SceneDetail.tsx
+++ b/src/renderer/components/sceneDetail/SceneDetail.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {IF, TF, ZF, TK, HTF, VTF} from '../../const';
 
 import Scene from '../../Scene';
+import ControlGroup from './ControlGroup';
 import DirectoryPicker from './DirectoryPicker';
 import SimpleCheckbox from '../ui/SimpleCheckbox';
 import SimpleOptionPicker from '../ui/SimpleOptionPicker';
@@ -20,30 +21,6 @@ type Props = {
   onDelete(scene: Scene): void,
   onUpdateScene(scene: Scene, fn: (scene: Scene) => void): void,
 };
-
-class ControlGroup extends React.Component {
-  readonly props: {
-    title: string,
-    isNarrow: boolean,
-    children: React.ReactNode,
-  };
-
-  render() {
-    return (
-      <form
-          className={`ControlGroup ${this.props.isNarrow ? 'm-narrow' : 'm-wide'}`}
-          onSubmit={this.preventDefault.bind(this)}>
-        <div className="ControlGroup__Title">{this.props.title}</div>
-        {this.props.children}
-      </form>
-    );
-  }
-
-  preventDefault(e: Event) {
-    e.preventDefault();
-    return;
-  }
-}
 
 export default class SceneDetail extends React.Component {
   readonly props: Props;
@@ -128,7 +105,6 @@ export default class SceneDetail extends React.Component {
           </ControlGroup>
 
           <ControlGroup title="Effects" isNarrow={true}>
-
             <SimpleCheckbox
               text="Cross-fade images"
               isOn={this.props.scene.crossFade}

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -14,6 +14,7 @@ $buttonBorder: #727272;
 
 $smallPadding: 0.5rem;
 $buttonBarHeight: 2rem + $smallPadding;
+$buttonSidebarWidth: 20rem + $smallPadding;
 
 @font-face {
   font-family: system;
@@ -74,11 +75,15 @@ a {
   background: linear-gradient(180deg, rgba(52,104,152,1) 0%, rgba(24,50,76,1) 100%);
 }
 
+.u-hidden {
+  display: none;
+}
+
 .u-button-row {
   @include noselect;
 
   position: relative;
-  z-index: 1;
+  z-index: 2;
   padding: $smallPadding $smallPadding 0 $smallPadding;
   height: $buttonBarHeight;
   @include buttonBarBackground;
@@ -95,6 +100,27 @@ a {
   .u-button {
     margin-right: $smallPadding;
     padding: 0.2rem;
+  }
+}
+
+.u-button-sidebar {
+  @include noselect;
+
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  padding: $smallPadding $smallPadding 0 $smallPadding;
+  width: $buttonSidebarWidth;
+  @include buttonBarBackground;
+
+  .SceneOptions {
+    display: inline-block;
+    margin-top: 0;
+    color: $black !important;
+    line-height: $buttonBarHeight;
   }
 }
 


### PR DESCRIPTION
The first commit makes  some small improvements to the fullscreen functionality: 
* When entering full screen, the React Menu is also hidden. This is repopulated when fullscreen is exited
* Fullscreen is automatically exited when the "Back" button is pressed. This prevents users (who don't know the hotkey) from getting stuck in fullscreen.

The second commit addresses #46 .
* A sidebar is added to `Player` with a subset of options from `SceneDetail` (namely Timing and Effects). 
  * For now, I just copied these elements from `SceneDetail` and implemented them the same.
  * They need to be pulled out into their own `Component`s eventually.
* Verified that changes made while playing take effect and persist when user returns to `SceneDetail`.