### PR TITLE
Move TimingGroup and EffectGroup into respective components

### DIFF
--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -5,12 +5,8 @@ import Sound from 'react-sound';
 
 import Scene from '../../Scene';
 import HeadlessScenePlayer from './HeadlessScenePlayer';
-import SimpleOptionPicker from "../ui/SimpleOptionPicker";
-import {HTF, TF, VTF, ZF} from "../../const";
-import SimpleTextInput from "../ui/SimpleTextInput";
-import SimpleCheckbox from "../ui/SimpleCheckbox";
-import SimpleSliderInput from "../ui/SimpleSliderInput";
-import ControlGroup from "../sceneDetail/ControlGroup";
+import TimingGroup from "../sceneDetail/TimingGroup";
+import EffectGroup from "../sceneDetail/EffectGroup";
 
 const keyMap = {
   playPause: ['Play/Pause', 'space'],
@@ -116,50 +112,13 @@ export default class Player extends React.Component {
 
         <div className={`u-button-sidebar ${this.state.isPlaying ? 'u-show-on-hover-only' : 'u-hidden'}`}>
           <h2 className="SceneOptions">Scene Options</h2>
-          <ControlGroup title="Timing" isNarrow={true}>
-            <SimpleOptionPicker
-                onChange={this.onChangeTimingFunction.bind(this)}
-                label="Timing"
-                value={this.props.scene.timingFunction}
-                keys={Object.values(TF)} />
-            <SimpleTextInput
-                isEnabled={this.props.scene.timingFunction === TF.constant}
-                onChange={this.onChangeTimingConstant.bind(this)}
-                label="Time between images (ms)"
-                value={this.props.scene.timingConstant.toString()} />
-          </ControlGroup>
+          <TimingGroup
+            scene={this.props.scene}
+            onUpdateScene={this.props.onUpdateScene.bind(this)}/>
 
-          <ControlGroup title="Effects" isNarrow={true}>
-            <SimpleCheckbox
-                text="Cross-fade images"
-                isOn={this.props.scene.crossFade}
-                onChange={this.onChangeCrossFade.bind(this)} />
-
-            <div className="ControlSubgroup">
-              <SimpleOptionPicker
-                  onChange={this.onChangeZoomType.bind(this)}
-                  label="Zoom Type"
-                  value={this.props.scene.zoomType}
-                  keys={Object.values(ZF)} />
-              <SimpleSliderInput
-                  isEnabled={true}
-                  onChange={this.onChangeEffectLevel.bind(this)}
-                  label={"Effect Length: " + this.props.scene.effectLevel + "s"}
-                  min={1}
-                  max={20}
-                  value={this.props.scene.effectLevel.toString()} />
-              <SimpleOptionPicker
-                  onChange={this.onChangeHorizTransType.bind(this)}
-                  label="Translate Horizontally"
-                  value={this.props.scene.horizTransType}
-                  keys={Object.values(HTF)} />
-              <SimpleOptionPicker
-                  onChange={this.onChangeVertTransType.bind(this)}
-                  label="Translate Vertically"
-                  value={this.props.scene.vertTransType}
-                  keys={Object.values(VTF)} />
-            </div>
-          </ControlGroup>
+          <EffectGroup
+            scene={this.props.scene}
+            onUpdateScene={this.props.onUpdateScene.bind(this)}/>
         </div>
       </div>
     );
@@ -277,22 +236,4 @@ export default class Player extends React.Component {
       Menu.setApplicationMenu(null);
     }
   }
-
-  update(fn: (scene: Scene) => void) {
-    this.props.onUpdateScene(this.props.scene, fn);
-  }
-
-  onChangeTimingFunction(fnId: string) { this.update((s) => { s.timingFunction = fnId; }); }
-
-  onChangeTimingConstant(constant: string) { this.update((s) => { s.timingConstant = constant; }); }
-
-  onChangeCrossFade(value: boolean) { this.update((s) => { s.crossFade = value; }); }
-
-  onChangeZoomType(type: string) { this.update((s) => { s.zoomType = type; }); }
-
-  onChangeEffectLevel(level: number) { this.update((s) => { s.effectLevel = level; }); }
-
-  onChangeHorizTransType(type: string) { this.update((s) => { s.horizTransType = type; }); }
-
-  onChangeVertTransType(type: string) { this.update((s) => { s.vertTransType = type; }); }
 };

--- a/src/renderer/components/sceneDetail/EffectGroup.tsx
+++ b/src/renderer/components/sceneDetail/EffectGroup.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import {HTF, VTF, ZF} from "../../const";
+import SimpleOptionPicker from "../ui/SimpleOptionPicker";
+import ControlGroup from "./ControlGroup";
+import Scene from "../../Scene";
+import SimpleSliderInput from "../ui/SimpleSliderInput";
+import SimpleCheckbox from "../ui/SimpleCheckbox";
+
+export default class EffectGroup extends React.Component {
+  readonly props: {
+    scene: Scene,
+    allScenes?: Array<Scene>,
+    onUpdateScene(scene: Scene, fn: (scene: Scene) => void): void,
+  };
+
+  render() {
+    return (
+        <ControlGroup title="Effects" isNarrow={true}>
+          <SimpleCheckbox
+            text="Cross-fade images"
+            isOn={this.props.scene.crossFade}
+            onChange={this.onChangeCrossFade.bind(this)} />
+
+          <div className="ControlSubgroup">
+            <SimpleOptionPicker
+              onChange={this.onChangeZoomType.bind(this)}
+              label="Zoom Type"
+              value={this.props.scene.zoomType}
+              keys={Object.values(ZF)} />
+            <SimpleSliderInput
+              isEnabled={true}
+              onChange={this.onChangeEffectLevel.bind(this)}
+              label={"Effect Length: " + this.props.scene.effectLevel + "s"}
+              min={1}
+              max={20}
+              value={this.props.scene.effectLevel.toString()} />
+            <SimpleOptionPicker
+              onChange={this.onChangeHorizTransType.bind(this)}
+              label="Translate Horizontally"
+              value={this.props.scene.horizTransType}
+              keys={Object.values(HTF)} />
+            <SimpleOptionPicker
+              onChange={this.onChangeVertTransType.bind(this)}
+              label="Translate Vertically"
+              value={this.props.scene.vertTransType}
+              keys={Object.values(VTF)} />
+          </div>
+
+          <div className="ControlSubgroup">
+            {this.props.allScenes != null && (
+            <SimpleOptionPicker
+              onChange={this.onChangeOverlaySceneID.bind(this)}
+              label="Overlay scene"
+              value={this.props.scene.overlaySceneID.toString()}
+              getLabel={this.getSceneName.bind(this)}
+              keys={["0"].concat(this.props.allScenes.map((s) => s.id.toString()))} />)}
+            {(this.props.allScenes != null || this.props.scene.overlaySceneID != 0) && (
+            <SimpleSliderInput
+              isEnabled={this.props.scene.overlaySceneID != 0}
+              onChange={this.onChangeOverlaySceneOpacity.bind(this)}
+              label={"Overlay opacity: " + (this.props.scene.overlaySceneOpacity * 100).toFixed(0) + '%'}
+              min={1}
+              max={99}
+              value={(this.props.scene.overlaySceneOpacity * 100).toString()} />)}
+          </div>
+        </ControlGroup>
+    );
+  }
+
+  getSceneName(id: string): string {
+    if (id === "0") return "None";
+    return this.props.allScenes.filter((s) => s.id.toString() === id)[0].name;
+  }
+
+  update(fn: (scene: Scene) => void) {
+    this.props.onUpdateScene(this.props.scene, fn);
+  }
+
+  onChangeCrossFade(value: boolean) { this.update((s) => { s.crossFade = value; }); }
+
+  onChangeZoomType(type: string) { this.update((s) => { s.zoomType = type; }); }
+
+  onChangeEffectLevel(level: number) { this.update((s) => { s.effectLevel = level; }); }
+
+  onChangeHorizTransType(type: string) { this.update((s) => { s.horizTransType = type; }); }
+
+  onChangeVertTransType(type: string) { this.update((s) => { s.vertTransType = type; }); }
+
+  onChangeOverlaySceneOpacity(value: string) { this.update((s) => { s.overlaySceneOpacity = parseInt(value, 10) / 100; }); }
+
+  onChangeOverlaySceneID(id: string) { this.update((s) => { s.overlaySceneID = parseInt(id, 10); }); }
+}

--- a/src/renderer/components/sceneDetail/SceneDetail.tsx
+++ b/src/renderer/components/sceneDetail/SceneDetail.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 
-import {IF, TF, ZF, TK, HTF, VTF} from '../../const';
+import {IF, TK} from '../../const';
 
 import Scene from '../../Scene';
 import ControlGroup from './ControlGroup';
 import DirectoryPicker from './DirectoryPicker';
 import SimpleCheckbox from '../ui/SimpleCheckbox';
 import SimpleOptionPicker from '../ui/SimpleOptionPicker';
-import SimpleTextInput from '../ui/SimpleTextInput';
-import SimpleSliderInput from "../ui/SimpleSliderInput";
 import SimpleURLInput from "../ui/SimpleURLInput";
 import URLModal from './URLModal';
+import TimingGroup from "./TimingGroup";
+import EffectGroup from "./EffectGroup";
 
 type Props = {
   scene?: Scene,
@@ -90,67 +90,15 @@ export default class SceneDetail extends React.Component {
               onImportURL={this.onImportURL.bind(this)}
               onChange={this.onChangeDirectories.bind(this)}/>
           </ControlGroup>
-        
-          <ControlGroup title="Timing" isNarrow={true}>
-            <SimpleOptionPicker
-              onChange={this.onChangeTimingFunction.bind(this)}
-              label="Timing"
-              value={this.props.scene.timingFunction}
-              keys={Object.values(TF)} />
-            <SimpleTextInput
-              isEnabled={this.props.scene.timingFunction === TF.constant}
-              onChange={this.onChangeTimingConstant.bind(this)}
-              label="Time between images (ms)"
-              value={this.props.scene.timingConstant.toString()} />
-          </ControlGroup>
 
-          <ControlGroup title="Effects" isNarrow={true}>
-            <SimpleCheckbox
-              text="Cross-fade images"
-              isOn={this.props.scene.crossFade}
-              onChange={this.onChangeCrossFade.bind(this)} />
+          <TimingGroup
+            scene={this.props.scene}
+            onUpdateScene={this.props.onUpdateScene.bind(this)}/>
 
-            <div className="ControlSubgroup">
-              <SimpleOptionPicker
-                onChange={this.onChangeZoomType.bind(this)}
-                label="Zoom Type"
-                value={this.props.scene.zoomType}
-                keys={Object.values(ZF)} />
-              <SimpleSliderInput
-                  isEnabled={true}
-                  onChange={this.onChangeEffectLevel.bind(this)}
-                  label={"Effect Length: " + this.props.scene.effectLevel + "s"}
-                  min={1}
-                  max={20}
-                  value={this.props.scene.effectLevel.toString()} />
-              <SimpleOptionPicker
-                  onChange={this.onChangeHorizTransType.bind(this)}
-                  label="Translate Horizontally"
-                  value={this.props.scene.horizTransType}
-                  keys={Object.values(HTF)} />
-              <SimpleOptionPicker
-                  onChange={this.onChangeVertTransType.bind(this)}
-                  label="Translate Vertically"
-                  value={this.props.scene.vertTransType}
-                  keys={Object.values(VTF)} />
-            </div>
-
-            <div className="ControlSubgroup">
-              <SimpleOptionPicker
-                onChange={this.onChangeOverlaySceneID.bind(this)}
-                label="Overlay scene"
-                value={this.props.scene.overlaySceneID.toString()}
-                getLabel={this.getSceneName.bind(this)}
-                keys={["0"].concat(this.props.allScenes.map((s) => s.id.toString()))} />
-              <SimpleSliderInput
-                isEnabled={this.props.scene.overlaySceneID != 0}
-                onChange={this.onChangeOverlaySceneOpacity.bind(this)}
-                label={"Overlay opacity: " + (this.props.scene.overlaySceneOpacity * 100).toFixed(0) + '%'}
-                min={1}
-                max={99}
-                value={(this.props.scene.overlaySceneOpacity * 100).toString()} />
-            </div>
-          </ControlGroup>
+          <EffectGroup
+            scene={this.props.scene}
+            allScenes={this.props.allScenes}
+            onUpdateScene={this.props.onUpdateScene.bind(this)}/>
 
           <ControlGroup title="Images" isNarrow={true}>
             <div className="ControlSubgroup">
@@ -208,11 +156,6 @@ export default class SceneDetail extends React.Component {
     this.setState({isShowingURLModal: false});
   }
 
-  getSceneName(id: string): string {
-    if (id === "0") return "none";
-    return this.props.allScenes.filter((s) => s.id.toString() === id)[0].name;
-  }
-
   play() {
     this.props.onPlay(this.props.scene);
   }
@@ -240,31 +183,11 @@ export default class SceneDetail extends React.Component {
 
   onChangeDirectories(directories: Array<string>) { this.update((s) => { s.directories = directories; }); }
 
-  onChangeOverlaySceneOpacity(value: string) {
-    this.update((s) => { s.overlaySceneOpacity = parseInt(value, 10) / 100; });
-  }
-
   onChangeImageTypeFilter(filter: string) { this.update((s) => { s.imageTypeFilter = filter; }); }
-
-  onChangeZoomType(type: string) { this.update((s) => { s.zoomType = type; }); }
-
-  onChangeEffectLevel(level: number) { this.update((s) => { s.effectLevel = level; }); }
-
-  onChangeHorizTransType(type: string) { this.update((s) => { s.horizTransType = type; }); }
-
-  onChangeVertTransType(type: string) { this.update((s) => { s.vertTransType = type; }); }
-
-  onChangeOverlaySceneID(id: string) { this.update((s) => { s.overlaySceneID = parseInt(id, 10); }); }
 
   onChangeTextKind(kind: string) { this.update((s) => { s.textKind = kind; }); }
 
   onChangeTextSource(textSource: string) { this.update((s) => { s.textSource = textSource; }); }
-
-  onChangeTimingFunction(fnId: string) { this.update((s) => { s.timingFunction = fnId; }); }
-
-  onChangeTimingConstant(constant: string) { this.update((s) => { s.timingConstant = constant; }); }
-
-  onChangeCrossFade(value: boolean) { this.update((s) => { s.crossFade = value; }); }
 
   onChangePlayFullGif(value: boolean) { this.update((s) => { s.playFullGif = value; }); }
 

--- a/src/renderer/components/sceneDetail/TimingGroup.tsx
+++ b/src/renderer/components/sceneDetail/TimingGroup.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import {TF} from "../../const";
+import SimpleTextInput from "../ui/SimpleTextInput";
+import SimpleOptionPicker from "../ui/SimpleOptionPicker";
+import ControlGroup from "./ControlGroup";
+import Scene from "../../Scene";
+
+export default class TimingGroup extends React.Component {
+  readonly props: {
+    scene?: Scene,
+    onUpdateScene(scene: Scene, fn: (scene: Scene) => void): void,
+  };
+
+  render() {
+    return (
+        <ControlGroup title="Timing" isNarrow={true}>
+          <SimpleOptionPicker
+            onChange={this.onChangeTimingFunction.bind(this)}
+            label="Timing"
+            value={this.props.scene.timingFunction}
+            keys={Object.values(TF)} />
+          <SimpleTextInput
+            isEnabled={this.props.scene.timingFunction === TF.constant}
+            onChange={this.onChangeTimingConstant.bind(this)}
+            label="Time between images (ms)"
+            value={this.props.scene.timingConstant.toString()} />
+        </ControlGroup>
+    );
+  }
+
+  update(fn: (scene: Scene) => void) {
+    this.props.onUpdateScene(this.props.scene, fn);
+  }
+
+  onChangeTimingFunction(fnId: string) { this.update((s) => { s.timingFunction = fnId; }); }
+
+  onChangeTimingConstant(constant: string) { this.update((s) => { s.timingConstant = constant; }); }
+}


### PR DESCRIPTION
This PR satisfies the outstanding requirements for #46. Timing and Effects controls have been moved into respective Components and are consistently applied to `SceneDetail` and `Player`.

Noticed that changing overlay scenes did not work as desired (they need to load and play at the same time it seems). This could be improved later. In the mean time, prevented overlay from being changed while playing (but opacity can be changed).