### PR TITLE
ContextMenu bugfix

### DIFF
--- a/src/renderer/components/player/HeadlessScenePlayer.tsx
+++ b/src/renderer/components/player/HeadlessScenePlayer.tsx
@@ -109,7 +109,7 @@ export default class HeadlessScenePlayer extends React.Component {
     showEmptyState: boolean,
     isPlaying: boolean,
     historyOffset: number,
-    setHistoryLength: (historyLength: number) => void,
+    setHistoryPaths: (historyPaths: string[]) => void,
     didFinishLoading: () => void,
   };
 
@@ -143,7 +143,7 @@ export default class HeadlessScenePlayer extends React.Component {
         {showImagePlayer && (
           <ImagePlayer
             historyOffset={this.props.historyOffset}
-            setHistoryLength={this.props.setHistoryLength}
+            setHistoryPaths={this.props.setHistoryPaths}
             maxInMemory={120}
             maxLoadingAtOnce={5}
             maxToRememberInHistory={500}

--- a/src/renderer/components/player/ImageContextMenu.tsx
+++ b/src/renderer/components/player/ImageContextMenu.tsx
@@ -24,6 +24,8 @@ export default class ImageContextMenu extends React.Component {
   }
 
   _handleContextMenu = (event : MouseEvent) => {
+    if (!this.props.fileURL || this.props.fileURL == null || this.props.fileURL.length == 0) return;
+
     event.preventDefault();
 
     this.setState({ visible: true });
@@ -102,6 +104,8 @@ export default class ImageContextMenu extends React.Component {
   };
 
   render() {
+    if (!this.props.fileURL || this.props.fileURL == null || this.props.fileURL.length == 0) return null;
+
     const isFile = this.props.fileURL.includes('file:///');
     let display = this.props.fileURL;
     if (isFile) {

--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -29,7 +29,7 @@ export default class ImagePlayer extends React.Component {
     fadeEnabled: boolean,
     playFullGif: boolean;
     imageSizeMin: number,
-    setHistoryLength: (historyLength: number) => void,
+    setHistoryPaths: (historyPaths: string[]) => void,
   };
 
   readonly state = {
@@ -114,8 +114,7 @@ export default class ImagePlayer extends React.Component {
             img={img}
             key={img.src}
             fadeState={this.props.fadeEnabled ? (img.src === imgs[0].src ? 'in' : 'out') : 'none'}
-            fadeDuration={this.state.timeToNextFrame / 2}
-            fileURL={this.state.historyPaths[(this.state.historyPaths.length - 1) + this.props.historyOffset]}/>;
+            fadeDuration={this.state.timeToNextFrame / 2} />;
         })}
       </div>
     );
@@ -257,7 +256,7 @@ export default class ImagePlayer extends React.Component {
       pastAndLatest: nextPastAndLatest,
       historyPaths: nextHistoryPaths,
     });
-    this.props.setHistoryLength(nextHistoryPaths.length);
+    this.props.setHistoryPaths(nextHistoryPaths);
 
     if (!schedule) return;
 

--- a/src/renderer/components/player/ImageView.tsx
+++ b/src/renderer/components/player/ImageView.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
-import ImageContextMenu from "./ImageContextMenu";
-
 
 const maxFadeSeconds = 5;
-
 
 export default class ImageView extends React.Component {
   readonly props: {
     img: HTMLImageElement,
-    fileURL: string,
     fadeState: string,
     fadeDuration: number,
   };
@@ -36,7 +32,7 @@ export default class ImageView extends React.Component {
     }
 
     const parentWidth = el.offsetWidth;
-    const parentHeight = el.offsetHeight
+    const parentHeight = el.offsetHeight;
     const parentAspect = parentWidth / parentHeight;
     const imgAspect = img.width / img.height;
 
@@ -81,8 +77,6 @@ export default class ImageView extends React.Component {
         className="ImageView u-fill-container"
         style={style}
         ref={this.contentRef}>
-        <ImageContextMenu
-          fileURL={this.props.fileURL}/>
       </div>);
   }
 }

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -7,6 +7,7 @@ import Scene from '../../Scene';
 import HeadlessScenePlayer from './HeadlessScenePlayer';
 import TimingGroup from "../sceneDetail/TimingGroup";
 import EffectGroup from "../sceneDetail/EffectGroup";
+import ImageContextMenu from "./ImageContextMenu";
 
 const keyMap = {
   playPause: ['Play/Pause', 'space'],
@@ -31,11 +32,11 @@ export default class Player extends React.Component {
     isOverlayLoaded: false,
     isPlaying: false,
     historyOffset: 0,
-    historyLength: 0,
+    historyPaths: Array<string>(),
   };
 
   render() {
-    const canGoBack = this.state.historyOffset > -(this.state.historyLength-1);
+    const canGoBack = this.state.historyOffset > -(this.state.historyPaths.length-1);
     const canGoForward = this.state.historyOffset < 0;
     const audioPlayStatus = this.state.isPlaying
       ? (Sound as any).status.PLAYING
@@ -53,7 +54,7 @@ export default class Player extends React.Component {
           showEmptyState={true}
           showText={true}
           didFinishLoading={this.playMain.bind(this)}
-          setHistoryLength={this.setHistoryLength.bind(this)} />
+          setHistoryPaths={this.setHistoryPaths.bind(this)} />
 
         {this.props.overlayScene && (
           <HeadlessScenePlayer
@@ -65,7 +66,7 @@ export default class Player extends React.Component {
             showEmptyState={false}
             showText={false}
             didFinishLoading={this.playOverlay.bind(this)}
-            setHistoryLength={this.nop.bind(this)} />
+            setHistoryPaths={this.nop.bind(this)} />
         )}
 
         <div className={`u-button-row ${this.state.isPlaying ? 'u-show-on-hover-only' : ''}`}>
@@ -120,6 +121,9 @@ export default class Player extends React.Component {
             scene={this.props.scene}
             onUpdateScene={this.props.onUpdateScene.bind(this)}/>
         </div>
+
+        <ImageContextMenu
+            fileURL={this.state.historyPaths[(this.state.historyPaths.length - 1) + this.state.historyOffset]}/>
       </div>
     );
   }
@@ -221,8 +225,8 @@ export default class Player extends React.Component {
     this.props.goBack();
   }
 
-  setHistoryLength(n: number) {
-    this.setState({historyLength: n});
+  setHistoryPaths(paths: string[]) {
+    this.setState({historyPaths: paths});
   }
 
   toggleFullscreen() {


### PR DESCRIPTION
This addresses #59 

First, tried to fix issue with pure CSS, but because it requires a `fixed` position, `z-index` has no effect and inherits the layering of its parent -- which is underneath the overlay 🤦‍♀️ So I had to move `ImageContextMenu` out into `Player` and pass it the appropriate data from `ImagePlayer`. It actually works even better now (in my opinion) because the context menu updates with the slideshow. I ensured it works properly with history