### PR TITLE
Fix visual appearance of loading indicator

### DIFF
--- a/src/renderer/components/ui/Progress.tsx
+++ b/src/renderer/components/ui/Progress.tsx
@@ -31,7 +31,7 @@ export default class Modal extends React.Component {
       },
     });
     this.setState({progress});
-    progress.animate(this.props.current / this.props.total);
+    progress.animate((this.props.current + 0.1) / (this.props.total + 0.1));
     progress.setText("<p>" + this.props.message + "</p><p>" + this.props.current + " / " + this.props.total + "</p>");
   }
 
@@ -41,7 +41,7 @@ export default class Modal extends React.Component {
 
   componentWillReceiveProps(props : any) {
     if (this.state && this.state.progress && props.current != this.props.current) {
-      this.state.progress.animate(props.current / this.props.total);
+      this.state.progress.animate((props.current + 0.1) / (this.props.total + 0.1));
       this.state.progress.setText("<p>" + this.props.message + "</p><p>" + props.current + " / " + this.props.total + "</p>");
     }
   }

--- a/src/renderer/components/ui/Progress.tsx
+++ b/src/renderer/components/ui/Progress.tsx
@@ -23,13 +23,16 @@ export default class Modal extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({progress: new ProgressBar.Circle('#progress', {
+    const progress = new ProgressBar.Circle('#progress', {
       color: '#FFFFFF',
       strokeWidth: 2,
       text: {
         value: this.props.message + "<br/>" + this.props.current + " / " + this.props.total,
       },
-    })});
+    });
+    this.setState({progress});
+    progress.animate(this.props.current / this.props.total);
+    progress.setText("<p>" + this.props.message + "</p><p>" + this.props.current + " / " + this.props.total + "</p>");
   }
 
   shouldComponentUpdate(nextProps: any, nextState: any) {

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -526,10 +526,13 @@ label.SimpleCheckbox {
   bottom: 0;
   left: 0;
 
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   .ProgressContainer {
-    position: absolute;
-    top: calc(50% - 10em);
-    left: calc(50% - 5em);
+    width: 20rem;
+    height: 20rem;
   }
 
   p {


### PR DESCRIPTION
Fully centered, and we render a tiny bit of the circle even if no directories have loaded yet.