### PR TITLE
GifInfo bugfix

### DIFF
--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -222,7 +222,9 @@ export default class ImagePlayer extends React.Component {
     // Filter gifs by animation
     if (url.toLocaleLowerCase().endsWith('.gif')) {
       // Get gif info. See https://github.com/Prinzhorn/gif-info
-      let info = gifInfo(toArrayBuffer(fs.readFileSync(new URL(url).pathname)));
+      let path = new URL(url).pathname;
+      path = path.substring(1, path.length);
+      let info = gifInfo(toArrayBuffer(fs.readFileSync(path)));
 
       // If gif is animated and we want to play entire length, store its duration
       if (info.animated && this.props.playFullGif) {


### PR DESCRIPTION
`gifInfo` expects a path like "D:\rips\0ni-chan" but `new URL(url).pathname` returns "\D:\rips\0ni-chan". Just removed first character from `pathname`