### PR TITLE
Adding support for 32bit Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ FlipFlip-darwin-x64/
 FlipFlip-win32-x64/
 FlipFlip-win32-ia32/
 FlipFlip-linux-x64/
+FlipFlip-linux-ia32/
 
 ## Ignore project files created by IntelliJ IDEA
 *.iml

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ app:
 	electron-packager app FlipFlip --platform=win32 --arch=x64 --overwrite
 	electron-packager app FlipFlip --platform=win32 --arch=ia32 --overwrite
 	electron-packager app FlipFlip --platform=linux --arch=x64 --overwrite
+	electron-packager app FlipFlip --platform=linux --arch=ia32 --overwrite
 	zip -r release/FlipFlip-Mac.zip FlipFlip-darwin-x64
 	zip -r release/FlipFlip-Windows.zip FlipFlip-win32-x64
 	zip -r release/FlipFlip-Windows-32bit.zip FlipFlip-win32-ia32
 	zip -r release/FlipFlip-Linux.zip FlipFlip-linux-x64
+	zip -r release/FlipFlip-Linux-32bit.zip FlipFlip-linux-ia32


### PR DESCRIPTION
1) Can this be pulled into the master - or alternatively can 32bit Linux support be added to the Makefile and the .gitignore files?

2) I have tested and it works on 32 bit Linux (Debian 9 Stretch)  :)  

3) FlipFlip also works on the RaspberryPi 3 - the MakeFile would need to be altered to include the "arm7l" architecture. 
`electron-packager app FlipFlip ==platform=linux --arch=armv7l`

