### PR TITLE
Fix to Cross-fade bug #78

### DIFF
--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -114,10 +114,9 @@ export default class ImagePlayer extends React.Component {
         }}>
         </div>
         {imgs.map((img) => {
-          this.state.nextImageID ++;
           return <ImageView
             img={img}
-            key={this.state.nextImageID.toString()}
+            key={(img as any).key}
             fadeState={this.props.fadeEnabled ? (img.src === imgs[0].src ? 'in' : 'out') : 'none'}
             fadeDuration={this.state.timeToNextFrame / 2} />;
         })}
@@ -182,9 +181,11 @@ export default class ImagePlayer extends React.Component {
       if (this.props.onLoaded && this.state.historyPaths.length == 1) {
         this.props.onLoaded();
       }
+      (img as any).key = this.state.nextImageID;
       this.setState({
         readyToDisplay: this.state.readyToDisplay.concat([img]),
         numBeingLoaded: Math.max(0, this.state.numBeingLoaded - 1),
+        nextImageID: this.state.nextImageID + 1,
       });
       if (this.state.pastAndLatest.length === 0) {
         this.advance(false, false);

--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -43,6 +43,7 @@ export default class ImagePlayer extends React.Component {
     historyPaths: Array<string>(),
     timeToNextFrame: 0,
     timeoutID: 0,
+    nextImageID: 0,
   };
 
   _isMounted = false;
@@ -113,9 +114,10 @@ export default class ImagePlayer extends React.Component {
         }}>
         </div>
         {imgs.map((img) => {
+          this.state.nextImageID ++;
           return <ImageView
             img={img}
-            key={img.src}
+            key={this.state.nextImageID.toString()}
             fadeState={this.props.fadeEnabled ? (img.src === imgs[0].src ? 'in' : 'out') : 'none'}
             fadeDuration={this.state.timeToNextFrame / 2} />;
         })}


### PR DESCRIPTION
reference: https://github.com/ififfy/flipflip/issues/78 

Created:   ImagePlayer.state.nextImageID=0
Incremented: ImagePlayer  render() method 
Used in the key:  key={this.state.nextImageID.toString()

not sure if this is exactly the way you wanted it doing - it works on my testing.