### PR TITLE
Menu Enhancements to support Player 'AlwaysOnTop' and Show/Hide of Menu

### DIFF
--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -17,6 +17,8 @@ const keyMap = {
   historyForward: ['Forward in time', 'right'],
   navigateBack: ['Go back to scene details', 'backspace'],
   toggleFullscreen: ['Toggle fullscreen', 'CommandOrControl+F'],
+  alwaysOnTop: ['Toggle On Top', 'CommandOrControl+T'],
+  toggleMenuBarDisplay: ['Show/Hide Menu', 'CommandOrControl+M'],
 };
 
 let originalMenu = Menu.getApplicationMenu();
@@ -293,7 +295,21 @@ export default class Player extends React.Component {
   setHistoryPaths(paths: string[]) {
     this.setState({ historyPaths: paths });
   }
+  /**
+   * Toggles if Player Window stays on top
+   */
+  alwaysOnTop() {
+    const window = getCurrentWindow();
+    window.setAlwaysOnTop(!window.isAlwaysOnTop());
+  }
 
+  /**
+   * Shows/Hides the MenuBar
+   */
+  toggleMenuBarDisplay() {
+    const window = getCurrentWindow();
+    window.setMenuBarVisibility(!window.isMenuBarVisible());
+  }
 
   /** 
   * Toggles fullscreen mode and MenuBar visibility

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -18,7 +18,7 @@ const keyMap = {
   navigateBack: ['Go back to scene details', 'backspace'],
   toggleFullscreen: ['Toggle fullscreen', 'CommandOrControl+F'],
   alwaysOnTop: ['Toggle On Top', 'CommandOrControl+T'],
-  toggleMenuBarDisplay: ['Show/Hide Menu', 'CommandOrControl+M'],
+  toggleMenuBarDisplay: ['Show/Hide Menu', 'CommandOrControl+^'],
 };
 
 let originalMenu = Menu.getApplicationMenu();


### PR DESCRIPTION
These are a few quick enhancements to the Player's MenuBar for your consideration:

1. Support the Player staying on top (which is particularly useful if in windowed mode);
2. Support explicit hiding and showing of the MenuBar.

