### PR TITLE
Making Version Number work in debug environment

### DIFF
--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -15,6 +15,13 @@ import SceneGenerator from "./library/SceneGenerator";
 import Player from './player/Player';
 import SceneDetail from './sceneDetail/SceneDetail';
 
+/**
+ * A compile-time global variable defined in webpack.config'
+ *  [plugins] section to pick up the version string from 
+ *   package.json
+ */
+declare var VERSION: string;
+
 class Route {
   kind: string;
   value: any;
@@ -62,11 +69,11 @@ try {
   };
 
   // validate initialState is rehydrated from a 'compatible' version
-  if (initialState.version != process.env.npm_package_version)
+  if (initialState.version != VERSION)
   {
     // ToDo (in future) deal with upgrading incompatible versions 
     //  For now the version is flattened to the current version.
-    initialState.version = process.env.npm_package_version;
+    initialState.version = VERSION;
   }
 } catch (e) {
   // who cares

--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -124,6 +124,7 @@ export default class Meta extends React.Component {
         {this.state.route.length === 0 && (
           <ScenePicker
             scenes={this.state.scenes}
+            version={this.state.version}
             onUpdateScenes={this.onUpdateScenes.bind(this)}
             onAdd={this.onAddScene.bind(this)}
             onSelect={this.onOpenScene.bind(this)}

--- a/src/renderer/components/ScenePicker.tsx
+++ b/src/renderer/components/ScenePicker.tsx
@@ -51,6 +51,7 @@ class Link extends React.Component {
 export default class ScenePicker extends React.Component {
   readonly props: {
     scenes: Array<Scene>,
+    version: string,
     canGenerate: boolean,
     onAdd(): void,
     onSelect(scene: Scene): void,
@@ -79,6 +80,7 @@ export default class ScenePicker extends React.Component {
               <div className="u-config" onClick={this.props.onConfig.bind(this)}/>
             </div>
             <h1>FlipFlip</h1>
+            <small>v{this.props.version}</small>
           </div>
 
           <div><Link url="https://github.com/ififfy/flipflip/wiki/FlipFlip-User-Manual">User manual</Link></div>

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const webpack = require('webpack');
 
 let mainConfig = {
     mode: 'development',
@@ -97,6 +98,10 @@ let rendererConfig = {
         new HtmlWebpackPlugin({
             template: path.resolve(__dirname, './src/renderer/index.html'),
         }),
+        // Create a global variable at compile time
+        new webpack.DefinePlugin({
+            VERSION: JSON.stringify(require("./package.json").version),
+          })
     ],
 };
 

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const webpack = require('webpack');
 
 let mainConfig = {
     mode: 'production',
@@ -97,6 +98,9 @@ let rendererConfig = {
         new HtmlWebpackPlugin({
             template: path.resolve(__dirname, './src/renderer/index.html'),
         }),
+        new webpack.DefinePlugin({
+            VERSION: JSON.stringify(require("./package.json").version)
+          }),
     ],
 };
 


### PR DESCRIPTION
This update to version numbering works by creating a global compile-time variable and thus also works in a debug environment.

Having committed - I'm wondering if rather than calling the variable "VERSION"  I should have perhaps called it ``__VERSION__``  to distinguish that this is a compile-time variable.

Let me know if you would like me to change it to ``__VERSION__`` before committing...

F3