### PR TITLE
Hydrate v2.0.0 Library from v1.2.0 Scenes

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -100,7 +100,7 @@ let rendererConfig = {
         }),
         // Create a global variable at compile time
         new webpack.DefinePlugin({
-            VERSION: JSON.stringify(require("./package.json").version),
+            __VERSION__: JSON.stringify(require("./package.json").version),
           })
     ],
 };

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -99,7 +99,7 @@ let rendererConfig = {
             template: path.resolve(__dirname, './src/renderer/index.html'),
         }),
         new webpack.DefinePlugin({
-            VERSION: JSON.stringify(require("./package.json").version)
+            __VERSION__: JSON.stringify(require("./package.json").version)
           }),
     ],
 };


### PR DESCRIPTION
# Hydrates v2.0.0 Library from v1.2.0 Scenes

- Compile-time global variable `VERSION` has been renamed to `__VERSION__` 
- On the first time v2.0.0 encounters an unversioned data.json configuration file - an attempt is made to upgrade it to v2.0.0
- The existing data.json file is archived in the .config folder by renaming to append an epoch time
- The new v.2.0.0 data.json file is initialized and any directories in existing scenes are hacked into the  sources of the Library ... taking care to de-duplicate entries
- Should upgrading the data.json file fail during the upgrade - then all things being equal the previous data.json file will have been archived - so it can be recovered or investigated etc. and a restart should self-heal and create a virgin v2.0.0 data.json file.

## To do
- Hydrating the Scenes needs to be done - similarly to the Library

## Queries
- I'm not sure of the hacks employed - there may be neater or more optimal ways of achieving the desired outcome. - I have made copious comments in the source code explaining the approach - and I am open for input and guidance on how to improve the coding.

F3
 

