### PR TITLE
Bug Fix: Enabling Scene Name to be edited (after deletion)

### DIFF
--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -841,6 +841,9 @@ label.SimpleCheckbox {
 
 .SceneDetail {
   .SceneName {
+    min-width: 10rem;
+    min-height: 2rem;
+    margin: 0;
     display: inline-block;
     margin-top: 0;
     color: $black !important;


### PR DESCRIPTION
Quick bug fix via `style.scss`

The editable area of the Scene Name in Scene Details was dynamic - so that when\if a user deleted the name and saved it the area was reduced to a width and height of 0 x 0.

I am not sure if these suggested values are acceptable i.e. 10rem ad 2 rem - so they can be changed to suit.

F3