### PR TITLE
Remove manual tag sorting, Order/Update/Remove source tags to match TagManager

### DIFF
--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -419,8 +419,26 @@ export default class Meta extends React.Component {
 
   endPlaySceneFromLibrary() {
     const newScenes = this.state.scenes;
-    newScenes.pop();
-    this.setState({route: [new Route({kind: 'library'})], scenes: newScenes});
+    const libraryID = newScenes.pop().libraryID;
+    const tagNames = this.state.tags.map((t) => t.name);
+    // Re-order the tags of the source we were playing
+    const newLibrary = this.state.library.map((s) => {
+      if (s.id == libraryID) {
+         s.tags = s.tags.sort((a, b) => {
+          const aIndex = tagNames.indexOf(a.name);
+          const bIndex = tagNames.indexOf(b.name);
+          if (aIndex < bIndex) {
+            return -1;
+          } else if (aIndex > bIndex) {
+            return 1;
+          } else {
+            return 0;
+          }
+        });
+      }
+      return s;
+    });
+    this.setState({route: [new Route({kind: 'library'})], scenes: newScenes, library: newLibrary});
   }
 
   manageTags() {
@@ -471,7 +489,25 @@ export default class Meta extends React.Component {
   }
 
   onUpdateTags(tags: Array<Tag>) {
-    this.setState({tags: tags});
+    // Go through each scene in the library
+    let newLibrary = this.state.library;
+    const tagNames = tags.map((t) => t.name);
+    for (let source of newLibrary) {
+      // Order the same as tags and remove deleted tags
+      source.tags = source.tags.filter((t) => tagNames.includes(t.name));
+      source.tags = source.tags.sort((a, b) => {
+        const aIndex = tagNames.indexOf(a.name);
+        const bIndex = tagNames.indexOf(b.name);
+        if (aIndex < bIndex) {
+          return -1;
+        } else if (aIndex > bIndex) {
+          return 1;
+        } else {
+          return 0;
+        }
+      });
+    }
+    this.setState({tags: tags, library: newLibrary});
   }
 
   onToggleTag(sourceID: number, tag: Tag) {

--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -491,13 +491,21 @@ export default class Meta extends React.Component {
   onUpdateTags(tags: Array<Tag>) {
     // Go through each scene in the library
     let newLibrary = this.state.library;
-    const tagNames = tags.map((t) => t.name);
+    const tagIDs = tags.map((t) => t.id);
     for (let source of newLibrary) {
-      // Order the same as tags and remove deleted tags
-      source.tags = source.tags.filter((t) => tagNames.includes(t.name));
+      // Remove deleted tags, update any edited tags, and order the same as tags
+      source.tags = source.tags.filter((t) => tagIDs.includes(t.id));
+      source.tags = source.tags.map((t) => {
+        for (let tag of tags) {
+          if (t.id == tag.id) {
+            t.name = tag.name;
+            return t;
+          }
+        }
+      });
       source.tags = source.tags.sort((a, b) => {
-        const aIndex = tagNames.indexOf(a.name);
-        const bIndex = tagNames.indexOf(b.name);
+        const aIndex = tagIDs.indexOf(a.id);
+        const bIndex = tagIDs.indexOf(b.id);
         if (aIndex < bIndex) {
           return -1;
         } else if (aIndex > bIndex) {

--- a/src/renderer/components/library/TagManager.tsx
+++ b/src/renderer/components/library/TagManager.tsx
@@ -134,8 +134,8 @@ export default class TagManager extends React.Component {
   }
 
   onAdd() {
-    let id = this.state.tags.length + 1;
-    this.state.tags.forEach((s) => {
+    let id = this.props.tags.length + 1;
+    this.props.tags.forEach((s) => {
       id = Math.max(s.id + 1, id);
     });
 

--- a/src/renderer/components/library/TagManager.tsx
+++ b/src/renderer/components/library/TagManager.tsx
@@ -134,7 +134,10 @@ export default class TagManager extends React.Component {
   }
 
   onAdd() {
-    let id = this.props.tags.length + 1;
+    let id = this.state.tags.length + 1;
+    this.state.tags.forEach((s) => {
+      id = Math.max(s.id + 1, id);
+    });
     this.props.tags.forEach((s) => {
       id = Math.max(s.id + 1, id);
     });

--- a/src/renderer/components/library/TagManager.tsx
+++ b/src/renderer/components/library/TagManager.tsx
@@ -120,9 +120,8 @@ export default class TagManager extends React.Component {
     this.props.goBack();
   }
 
-  applyConfig(): boolean {
+  applyConfig() {
     this.props.onUpdateTags(this.state.tags);
-    return true;
   }
 
   toggleRemoveMode() {
@@ -151,10 +150,9 @@ export default class TagManager extends React.Component {
 
   onEdit(tagID: number, e: Event) {
     e.preventDefault();
-    this.setState({isEditing: tagID});
     // If user left input blank, remove it from list of sources
     // Also prevent user from inputing duplicate source
-    this.setState({tags:
+    this.setState({isEditing: tagID, tags:
       removeDuplicatesBy((t: Tag) => t.name,
         this.state.tags.filter((t) => t.name != ""))});
   }

--- a/src/renderer/components/library/TagManager.tsx
+++ b/src/renderer/components/library/TagManager.tsx
@@ -12,6 +12,7 @@ export default class TagManager extends React.Component {
   };
 
   readonly state = {
+    tags: Array<Tag>(),
     removeTags: false,
     isEditing: -1,
     sortable: Sortable,
@@ -23,6 +24,16 @@ export default class TagManager extends React.Component {
         <div className="u-button-row">
           <div className="u-abs-center">
             <h2 className="TagManager__TagManagerHeader">Tag Manager</h2>
+          </div>
+          <div className="u-button-row-right">
+            <div className="Config__Apply u-button u-clickable"
+                 onClick={this.applyConfig.bind(this)}>
+              Apply
+            </div>
+            <div className="Config__OK u-button u-clickable"
+                 onClick={this.onOK.bind(this)}>
+              OK
+            </div>
           </div>
 
           <div className="BackButton u-button u-clickable" onClick={this.props.goBack}>Back</div>
@@ -37,13 +48,13 @@ export default class TagManager extends React.Component {
                  onClick={this.toggleRemoveMode.bind(this)}>Done</div>
           )}
           {!this.state.removeTags && (
-            <div className={`u-button u-float-left ${this.props.tags.length == 0 ? 'u-disabled' : 'u-clickable'} `}
-                 onClick={this.props.tags.length == 0 ? this.nop : this.toggleRemoveMode.bind(this)}>- Remove Tags</div>
+            <div className={`u-button u-float-left ${this.state.tags.length == 0 ? 'u-disabled' : 'u-clickable'} `}
+                 onClick={this.state.tags.length == 0 ? this.nop : this.toggleRemoveMode.bind(this)}>- Remove Tags</div>
           )}
         </div>
 
         <div id="tags" className="TagManager__Tags">
-          {this.props.tags.map((tag) =>
+          {this.state.tags.map((tag) =>
             <div className={`TagManager__Tag u-clickable ${this.state.removeTags ? 'u-destructive-bg' : ''}`}
                  onClick={this.state.removeTags ? this.onRemove.bind(this, tag.id) : this.onEdit.bind(this, tag.id)}
                  key={tag.id}>
@@ -66,7 +77,7 @@ export default class TagManager extends React.Component {
           )}
         </div>
 
-        {this.props.tags.length == 0 && (
+        {this.state.tags.length == 0 && (
           <div className="TagManager__Empty">
             You haven't added any tags yet.
           </div>
@@ -81,9 +92,9 @@ export default class TagManager extends React.Component {
   }
 
   onEnd(evt: any) {
-    let newTags = this.props.tags;
+    let newTags = this.state.tags;
     arrayMove(newTags, evt.oldIndex, evt.newIndex);
-    this.props.onUpdateTags(newTags);
+    this.setState({tags: newTags});
   }
 
   componentDidMount() {
@@ -92,10 +103,27 @@ export default class TagManager extends React.Component {
       easing: "cubic-bezier(1, 0, 0, 1)",
       onEnd: this.onEnd.bind(this),
     });
-    this.setState({sortable: sortable});
+
+    // Make a deep copy of Tags
+    // For some reason, shallow copy was still modifying props' Tags
+    let newTags = Array<Tag>();
+    for (let tag of this.props.tags) {
+      newTags.push(JSON.parse(JSON.stringify(tag)));
+    }
+    this.setState({sortable: sortable, tags: newTags});
   }
 
   nop() {}
+
+  onOK() {
+    this.applyConfig();
+    this.props.goBack();
+  }
+
+  applyConfig(): boolean {
+    this.props.onUpdateTags(this.state.tags);
+    return true;
+  }
 
   toggleRemoveMode() {
     this.state.sortable.option("disabled", !this.state.removeTags);
@@ -103,22 +131,22 @@ export default class TagManager extends React.Component {
   };
 
   onRemove(tagID: number) {
-    this.props.onUpdateTags(this.props.tags.filter((t) => t.id != tagID));
+    this.setState({tags: this.state.tags.filter((t) => t.id != tagID)});
   }
 
   onAdd() {
-    let id = this.props.tags.length + 1;
-    this.props.tags.forEach((s) => {
+    let id = this.state.tags.length + 1;
+    this.state.tags.forEach((s) => {
       id = Math.max(s.id + 1, id);
     });
 
     this.setState({isEditing: id});
-    let newTags = this.props.tags;
+    let newTags = this.state.tags;
     newTags.push(new Tag({
       name: "",
       id: id,
     }));
-    this.props.onUpdateTags(newTags);
+    this.setState({tags: newTags});
   }
 
   onEdit(tagID: number, e: Event) {
@@ -126,20 +154,21 @@ export default class TagManager extends React.Component {
     this.setState({isEditing: tagID});
     // If user left input blank, remove it from list of sources
     // Also prevent user from inputing duplicate source
-    this.props.onUpdateTags(
+    this.setState({tags:
       removeDuplicatesBy((t: Tag) => t.name,
-        this.props.tags.filter((t) => t.name != "")));
+        this.state.tags.filter((t) => t.name != ""))});
   }
 
   onEditTag(tagID: number, e: React.FormEvent<HTMLInputElement>) {
-    this.props.onUpdateTags(this.props.tags.map(
-      function map(tag: Tag) {
-        if (tag.id == tagID) {
-          tag.name = e.currentTarget.value;
-        }
-        return tag;
-      })
-    );
+    this.setState({
+      tags: this.state.tags.map(
+        function map(tag: Tag) {
+          if (tag.id == tagID) {
+            tag.name = e.currentTarget.value;
+          }
+          return tag;
+        })
+    });
   }
 
 }

--- a/src/renderer/components/sceneDetail/SourcePicker.tsx
+++ b/src/renderer/components/sceneDetail/SourcePicker.tsx
@@ -219,16 +219,6 @@ export default class SourcePicker extends React.Component {
     this.props.onUpdateSources(newSources);
   }
 
-  onEndTag(sourceID: number, evt: any) {
-    let newSources = this.props.sources;
-    for (let source of newSources) {
-      if (source.id == sourceID) {
-        arrayMove(source.tags, evt.oldIndex, evt.newIndex);
-      }
-    }
-    this.props.onUpdateSources(newSources);
-  }
-
   componentDidMount() {
     this.setState({sortable: null});
     this.initSortable();
@@ -241,19 +231,13 @@ export default class SourcePicker extends React.Component {
 
   initSortable() {
     if (!this.state.sortable && this.props.sources.length > 0) {
-      let sortable = Sortable.create(document.getElementById('sources'), {
-        animation: 150,
-        easing: "cubic-bezier(1, 0, 0, 1)",
-        onEnd: this.onEnd.bind(this),
-      });
-      for (let s = 0; s < this.props.sources.length; s++) {
-        Sortable.create(document.getElementById('tags-' + this.props.sources[s].id), {
+      this.setState({sortable:
+        Sortable.create(document.getElementById('sources'), {
           animation: 150,
           easing: "cubic-bezier(1, 0, 0, 1)",
-          onEnd: this.onEndTag.bind(this, this.props.sources[s].id),
-        });
-      }
-      this.setState({sortable: sortable});
+          onEnd: this.onEnd.bind(this),
+        })
+      });
     }
   }
 

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -649,7 +649,6 @@ label.SimpleCheckbox {
           color: $uiGray;
           padding-left: 1rem;
           font-size: 12px;
-          cursor: move;
         }
       }
 

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -17,10 +17,7 @@ $buttonBarHeight: 2rem + $smallPadding;
 $buttonSidebarWidth: 21rem + $smallPadding;
 
 // Unicode Emoji characters
-$emojiDice: '\1F3B2';
-$emojiGear: '\2699';
-$emojiPencil: '\270E';
-$emojiDownArrow: '\1F80B';
+$emojiPencil: '\270E'; // ✎
 
 @font-face {
   font-family: system;


### PR DESCRIPTION
This PR addresses #104 & #105 

The current tag ordering is haphazard and can look confusing. Instead, just order them all by the order in `TagManager` . Also, delete/rename a tag from sources if it is deleted/renamed from `TagManager`.

Any issues? 🙂