### PR TITLE
Allow Backup/Restore

### DIFF
--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -54,7 +54,6 @@ try {
   // who cares
 }
 const savePath = path.join(saveDir, 'data.json');
-const backupPath = path.join(saveDir, 'data - Backup.json');
 console.log("Saving to", savePath);
 
 try {
@@ -305,24 +304,35 @@ export default class Meta extends React.Component {
   }
 
   backup() {
-    archiveFile(savePath);
-    fs.copyFileSync(savePath, backupPath);
+    try {
+      archiveFile(savePath);
+    } catch (e) {
+      alert("Backup error:\n" + e);
+      return;
+    }
+    alert("Backup success!");
   }
 
-  restore() {
-    const data = JSON.parse(readFileSync(backupPath, 'utf-8'));
-    this.setState({
-      version: data.version,
-      autoEdit: data.autoEdit,
-      isSelect: data.isSelect,
-      config: data.config,
-      scenes: data.scenes.map((s: any) => new Scene(s)),
-      library: data.library.map((s: any) => new LibrarySource(s)),
-      tags: data.tags.map((t: any) => new Tag(t)),
-      route: data.route.map((s: any) => new Route(s)),
-      libraryYOffset: 0,
-      libraryFilters: Array<string>(),
-    });
+  restore(backupFile: string) {
+    try {
+      const data = JSON.parse(readFileSync(backupFile, 'utf-8'));
+      this.setState({
+        version: data.version,
+        autoEdit: data.autoEdit,
+        isSelect: data.isSelect,
+        config: data.config,
+        scenes: data.scenes.map((s: any) => new Scene(s)),
+        library: data.library.map((s: any) => new LibrarySource(s)),
+        tags: data.tags.map((t: any) => new Tag(t)),
+        route: data.route.map((s: any) => new Route(s)),
+        libraryYOffset: 0,
+        libraryFilters: Array<string>(),
+      });
+    } catch (e) {
+      alert("Restore error:\n" + e);
+      return;
+    }
+    alert("Restore success!");
   }
 
   goBack() {

--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -54,6 +54,7 @@ try {
   // who cares
 }
 const savePath = path.join(saveDir, 'data.json');
+const backupPath = path.join(saveDir, 'data - Backup.json');
 console.log("Saving to", savePath);
 
 try {
@@ -291,6 +292,8 @@ export default class Meta extends React.Component {
             goBack={this.goBack.bind(this)}
             updateConfig={this.updateConfig.bind(this)}
             onDefault={this.onDefaultConfig.bind(this)}
+            onBackup={this.backup.bind(this)}
+            onRestore={this.restore.bind(this)}
           />
         )}
       </div>
@@ -299,6 +302,27 @@ export default class Meta extends React.Component {
 
   save() {
     writeFileSync(savePath, JSON.stringify(this.state), 'utf-8');
+  }
+
+  backup() {
+    archiveFile(savePath);
+    fs.copyFileSync(savePath, backupPath);
+  }
+
+  restore() {
+    const data = JSON.parse(readFileSync(backupPath, 'utf-8'));
+    this.setState({
+      version: data.version,
+      autoEdit: data.autoEdit,
+      isSelect: data.isSelect,
+      config: data.config,
+      scenes: data.scenes.map((s: any) => new Scene(s)),
+      library: data.library.map((s: any) => new LibrarySource(s)),
+      tags: data.tags.map((t: any) => new Tag(t)),
+      route: data.route.map((s: any) => new Route(s)),
+      libraryYOffset: 0,
+      libraryFilters: Array<string>(),
+    });
   }
 
   goBack() {

--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as React from 'react';
 import path from 'path';
 
-import {removeDuplicatesBy} from "../utils";
+import {getBackups, removeDuplicatesBy, saveDir} from "../utils";
 import Config from "../Config";
 import Scene from '../Scene';
 import ScenePicker from './ScenePicker';
@@ -47,7 +47,6 @@ let initialState = {
   libraryFilters: Array<string>(),
 };
 
-const saveDir = path.join(remote.app.getPath('appData'), 'flipflip');
 try {
   mkdirSync(saveDir);
 } catch (e) {
@@ -293,6 +292,7 @@ export default class Meta extends React.Component {
             onDefault={this.onDefaultConfig.bind(this)}
             onBackup={this.backup.bind(this)}
             onRestore={this.restore.bind(this)}
+            onClean={this.cleanBackups.bind(this)}
           />
         )}
       </div>
@@ -333,6 +333,24 @@ export default class Meta extends React.Component {
       return;
     }
     alert("Restore success!");
+  }
+
+  cleanBackups() {
+    const backups = getBackups();
+    backups.shift(); // Keep the newest backup
+    let error;
+    for (let backup of backups) {
+      fs.unlink(saveDir + path.sep + backup, (err) => {
+        if (err) {
+          error = err;
+        }
+      });
+    }
+    if (error) {
+      alert("Cleanup error:\n" + error);
+    } else {
+      alert("Cleanup success!");
+    }
   }
 
   goBack() {

--- a/src/renderer/components/config/BackupGroup.tsx
+++ b/src/renderer/components/config/BackupGroup.tsx
@@ -113,7 +113,7 @@ export default class BackupGroup extends React.Component {
     this.setState({
       backup: this.state.backups[0],
       confirmTitle: "Restore",
-      confirmMessage: "You are about to override your data with the most recent backup. Continue?",
+      confirmMessage: "Choose a backup to restore from:",
       confirmShowSelect: true,
       confirmFunction: this.restore,
     });

--- a/src/renderer/components/config/BackupGroup.tsx
+++ b/src/renderer/components/config/BackupGroup.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import * as fs from "fs";
+import path from "path";
+import {remote} from "electron";
+
+import ControlGroup from "../sceneDetail/ControlGroup";
+
+const saveDir = path.join(remote.app.getPath('appData'), 'flipflip');
+const backupPath = path.join(saveDir, 'data - Backup.json');
+
+export default class BackupGroup extends React.Component {
+
+  readonly props: {
+    restore(): void,
+    backup(): void,
+  };
+
+  render() {
+    const hasBackup = fs.existsSync(backupPath);
+    return(
+      <ControlGroup title="Backup" isNarrow={true}>
+        <div className="ControlSubgroup">
+          <button onClick={this.props.backup.bind(this)} className="u-button u-clickable" >
+            Backup Data
+          </button>
+          <button onClick={hasBackup ? this.props.restore.bind(this) : this.nop} className={`u-button ${hasBackup ? 'u-clickable' : 'u-disabled'}`} >
+            Restore Last Backup
+          </button>
+        </div>
+      </ControlGroup>
+    );
+  }
+
+  nop() {}
+}

--- a/src/renderer/components/config/BackupGroup.tsx
+++ b/src/renderer/components/config/BackupGroup.tsx
@@ -4,7 +4,6 @@ import path from "path";
 import {getBackups, saveDir} from "../../utils";
 import ControlGroup from "../sceneDetail/ControlGroup";
 import Modal from "../ui/Modal";
-import SimpleOptionPicker from "../ui/SimpleOptionPicker";
 
 
 export default class BackupGroup extends React.Component {
@@ -52,11 +51,15 @@ export default class BackupGroup extends React.Component {
           <Modal onClose={this.closeConfirm.bind(this)} title={this.state.confirmTitle}>
             <p>{this.state.confirmMessage}</p>
             {this.state.confirmShowSelect && (
-              <SimpleOptionPicker
-                label=""
+              <div className="SimpleOptionPicker">
+                <select
                 value={this.state.backup}
-                keys={this.state.backups.map((b) => this.convertFromEpoch(b))}
-                onChange={this.onChangeBackup.bind(this)} />
+                onChange={this.onChangeBackup.bind(this)}>
+                {this.state.backups.map((b) =>
+                  <option value={b} key={b}>{this.convertFromEpoch(b)}</option>
+                )}
+                </select>
+              </div>
             )}
             <div className="u-button u-float-right" onClick={this.state.confirmFunction.bind(this)}>
               Confirm
@@ -83,14 +86,8 @@ export default class BackupGroup extends React.Component {
     return date.toLocaleString();
   }
 
-  convertToEpoch(localeString: string) {
-    const date = new Date(localeString);
-    return date.getTime();
-  }
-
-  onChangeBackup(backup: string) {
-    const backupFile = 'data.json.' + this.convertToEpoch(backup);
-    this.setState({backup: backupFile});
+  onChangeBackup(e: React.FormEvent<HTMLSelectElement>) {
+    this.setState({backup: e.currentTarget.value});
   }
 
   onClean() {

--- a/src/renderer/components/config/BackupGroup.tsx
+++ b/src/renderer/components/config/BackupGroup.tsx
@@ -4,32 +4,122 @@ import path from "path";
 import {remote} from "electron";
 
 import ControlGroup from "../sceneDetail/ControlGroup";
+import Modal from "../ui/Modal";
+import SimpleOptionPicker from "../ui/SimpleOptionPicker";
 
 const saveDir = path.join(remote.app.getPath('appData'), 'flipflip');
-const backupPath = path.join(saveDir, 'data - Backup.json');
 
 export default class BackupGroup extends React.Component {
 
   readonly props: {
-    restore(): void,
     backup(): void,
+    restore(backupFile: string): void,
+  };
+
+  readonly state = {
+    backups: Array<string>(),
+    backup: "",
+    confirmMessage: "",
+    confirmTitle: "",
+    confirmFunction: this.nop,
   };
 
   render() {
-    const hasBackup = fs.existsSync(backupPath);
+    const hasBackup = this.state.backups.length > 0;
     return(
       <ControlGroup title="Backup" isNarrow={true}>
         <div className="ControlSubgroup">
-          <button onClick={this.props.backup.bind(this)} className="u-button u-clickable" >
+          <button onClick={this.onBackup.bind(this)} className="u-button u-clickable" >
             Backup Data
           </button>
-          <button onClick={hasBackup ? this.props.restore.bind(this) : this.nop} className={`u-button ${hasBackup ? 'u-clickable' : 'u-disabled'}`} >
-            Restore Last Backup
+          <button onClick={hasBackup ? this.onRestore.bind(this) : this.nop} className={`u-button ${hasBackup ? 'u-clickable' : 'u-disabled'}`} >
+            Restore Backup
           </button>
         </div>
+        <br/>
+        <span>
+          Last Backup: {hasBackup ? this.convertFromEpoch(this.state.backups[0]) : '--'}
+        </span>
+        {this.state.confirmMessage != "" && (
+          <Modal onClose={this.closeConfirm.bind(this)} title={this.state.confirmTitle}>
+            <p>{this.state.confirmMessage}</p>
+            <SimpleOptionPicker
+              label=""
+              value={this.state.backup}
+              keys={this.state.backups.map((b) => this.convertFromEpoch(b))}
+              onChange={this.onChangeBackup.bind(this)}/>
+            <div className="u-button u-float-right" onClick={this.state.confirmFunction.bind(this)}>
+              Confirm
+            </div>
+          </Modal>
+        )}
       </ControlGroup>
     );
   }
 
   nop() {}
+
+  componentDidMount() {
+    this.refreshBackups();
+  }
+
+  refreshBackups() {
+    const files = fs.readdirSync(saveDir);
+    const backups = [];
+    for (let file of files) {
+      if (file.startsWith("data.json.")) {
+        backups.push(file);
+      }
+    }
+    backups.sort((a, b) => {
+      if (a > b) {
+        return -1;
+      } else if (a < b) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    this.setState({backups: backups});
+  }
+
+  convertFromEpoch(backupFile: string) {
+    const epochString = backupFile.substring(backupFile.lastIndexOf(".") + 1);
+    const date = new Date(Number.parseInt(epochString));
+    return date.toLocaleString();
+  }
+
+  convertToEpoch(localeString: string) {
+    const date = new Date(localeString);
+    return date.getTime();
+  }
+
+  onChangeBackup(backup: string) {
+    const backupFile = 'data.json.' + this.convertToEpoch(backup);
+    this.setState({backup: backupFile});
+  }
+
+  onRestore() {
+    this.setState({
+      backup: this.state.backups[0],
+      confirmTitle: "Restore",
+      confirmMessage: "You are about to override your data with the most recent backup. Continue?",
+      confirmFunction: this.restore
+    });
+  }
+
+  restore() {
+    this.props.restore(saveDir + path.sep + this.state.backup);
+    this.closeConfirm();
+  }
+
+  onBackup() {
+    this.props.backup();
+    this.closeConfirm();
+    this.refreshBackups();
+  }
+
+  closeConfirm() {
+    this.setState({confirmTitle: "", confirmMessage: "", confirmFunction: this.nop});
+  }
 }

--- a/src/renderer/components/config/ConfigForm.tsx
+++ b/src/renderer/components/config/ConfigForm.tsx
@@ -14,6 +14,7 @@ import ImageGroup from "../sceneDetail/ImageGroup";
 import TextGroup from "../sceneDetail/TextGroup";
 import TimingGroup from "../sceneDetail/TimingGroup";
 import Modal from "../ui/Modal";
+import BackupGroup from "./BackupGroup";
 
 export default class ConfigForm extends React.Component {
   readonly props: {
@@ -22,6 +23,8 @@ export default class ConfigForm extends React.Component {
     goBack(): void,
     updateConfig(config: Config): void,
     onDefault(): void,
+    onBackup(): void,
+    onRestore(): void,
   };
 
   readonly state = {
@@ -82,6 +85,10 @@ export default class ConfigForm extends React.Component {
             settings={this.state.config.remoteSettings}
             activateReddit={this.showActivateRedditNotice.bind(this)}
             onUpdateSettings={this.onUpdateRemoteSettings.bind(this)}/>
+
+          <BackupGroup
+            restore={this.props.onRestore.bind(this)}
+            backup={this.props.onBackup.bind(this)}/>
         </div>
 
         {this.state.modalMessages.length > 0 && (

--- a/src/renderer/components/config/ConfigForm.tsx
+++ b/src/renderer/components/config/ConfigForm.tsx
@@ -25,6 +25,7 @@ export default class ConfigForm extends React.Component {
     onDefault(): void,
     onBackup(): void,
     onRestore(backupFile: string): void,
+    onClean(): void,
   };
 
   readonly state = {
@@ -87,8 +88,9 @@ export default class ConfigForm extends React.Component {
             onUpdateSettings={this.onUpdateRemoteSettings.bind(this)}/>
 
           <BackupGroup
+            backup={this.props.onBackup.bind(this)}
             restore={this.props.onRestore.bind(this)}
-            backup={this.props.onBackup.bind(this)}/>
+            clean={this.props.onClean.bind(this)}/>
         </div>
 
         {this.state.modalMessages.length > 0 && (

--- a/src/renderer/components/config/ConfigForm.tsx
+++ b/src/renderer/components/config/ConfigForm.tsx
@@ -90,7 +90,7 @@ export default class ConfigForm extends React.Component {
           <BackupGroup
             backup={this.props.onBackup.bind(this)}
             restore={this.props.onRestore.bind(this)}
-            clean={this.props.onClean.bind(this)}/>
+            clean={this.props.onClean.bind(this)} />
         </div>
 
         {this.state.modalMessages.length > 0 && (
@@ -105,6 +105,12 @@ export default class ConfigForm extends React.Component {
         )}
       </div>
     )
+  }
+
+  componentWillReceiveProps(props: any) {
+    if (props.config != this.props.config) {
+      this.setState({config: props.config});
+    }
   }
 
   showActivateRedditNotice() {

--- a/src/renderer/components/config/ConfigForm.tsx
+++ b/src/renderer/components/config/ConfigForm.tsx
@@ -24,7 +24,7 @@ export default class ConfigForm extends React.Component {
     updateConfig(config: Config): void,
     onDefault(): void,
     onBackup(): void,
-    onRestore(): void,
+    onRestore(backupFile: string): void,
   };
 
   readonly state = {

--- a/src/renderer/components/ui/Progress.tsx
+++ b/src/renderer/components/ui/Progress.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ProgressBar from 'progressbar.js'
 
-export default class Modal extends React.Component {
+export default class Progress extends React.Component {
   readonly props: {
     total: number,
     current: number,

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -1076,7 +1076,7 @@ label.SimpleCheckbox {
     &:before {
       content: '╳';
       position: relative;
-      bottom: 8px;
+      bottom: 7px;
     }
   }
 }

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -5,7 +5,29 @@ import path from 'path';
 import {ST} from "./const";
 import en from "./en";
 import Config from "./Config";
+import * as fs from "fs";
 
+export const saveDir = path.join(remote.app.getPath('appData'), 'flipflip');
+
+export function getBackups() {
+  const files = fs.readdirSync(saveDir);
+  const backups = [];
+  for (let file of files) {
+    if (file.startsWith("data.json.")) {
+      backups.push(file);
+    }
+  }
+  backups.sort((a, b) => {
+    if (a > b) {
+      return -1;
+    } else if (a < b) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+  return backups;
+}
 
 export function getPath() {
   return path.join(remote.app.getPath('appData'), 'flipflip');


### PR DESCRIPTION
This is some starting work for Backup/Restore functionality (#132) . Currently, this is very simplistic, so I'd love some input about how this should ultimately work for users.

Currently (from `Config`):
* User hits "Backup Data"
  * FlipFlip creates a timestamped archive file
  * FlipFlip creates (or overrides) the file "data - Backup.json"
* User hits "Restore Last Backup" (only enabled if "data - Backup.json" exists)
  * Sets `Meta` state to contents of "data - Backup.json"

The above process just leaves a bunch of archive files, while overriding the backup. I think it'd be better to at least (1) use the most recent archive file or (2) provide a list of versions to restore from.

But I wasn't sure if it made sense for a user to want to restore an older backup. The only reason I could think of... was you accidentally hit "Backup Data" when you meant to hit "Restore Last Backup", but this problem would be solved with a confirmation dialog.

I think the following would be good, but please let me know if you think of anything else:
* Timestamp backup files (separate from init archive?)
* Show latest timestamp: e.g. "Last Backup: MM/dd/YYYY"
* Alert/Confirm user action: e.g. "Backup created", "Backup restored"