### PR TITLE
Persisting alwaysOnTop and  menuBarVisibility

### DIFF
--- a/src/renderer/Config.tsx
+++ b/src/renderer/Config.tsx
@@ -57,6 +57,12 @@ interface CacheSettingsI {
   maxSize: number;
 }
 
+interface DisplaySettingsI {
+  alwaysOnTop: boolean;
+  showMenu: boolean;
+}
+
+
 export class SceneSettings implements SceneSettingsI {
   [key: string]: string | number | boolean;
 
@@ -118,11 +124,18 @@ export class CacheSettings implements CacheSettingsI {
   maxSize = 500; // Size in MB
 }
 
+export class DisplaySettings  implements DisplaySettingsI {
+  [key: string]:boolean;
+  alwaysOnTop = false;
+  showMenu = true;
+}
+
 export default class Config {
   defaultScene = new SceneSettings();
   remoteSettings = new RemoteSettings();
   caching = new CacheSettings();
-
+  displaySettings = new DisplaySettings();
+  
   constructor(init?: Partial<Config>) {
     Object.assign(this, init);
 

--- a/src/renderer/Config.tsx
+++ b/src/renderer/Config.tsx
@@ -58,10 +58,11 @@ interface CacheSettingsI {
 }
 
 interface DisplaySettingsI {
+  [key: string]: boolean;
   alwaysOnTop: boolean;
   showMenu: boolean;
+  fullScreen: boolean;
 }
-
 
 export class SceneSettings implements SceneSettingsI {
   [key: string]: string | number | boolean;
@@ -125,9 +126,11 @@ export class CacheSettings implements CacheSettingsI {
 }
 
 export class DisplaySettings  implements DisplaySettingsI {
-  [key: string]:boolean;
+  [key: string]: boolean;
+
   alwaysOnTop = false;
   showMenu = true;
+  fullScreen = false;
 }
 
 export default class Config {
@@ -153,6 +156,11 @@ export default class Config {
     for (let key of Object.keys(new CacheSettings())) {
       if (this.caching[key] == null) {
         this.caching[key] = new CacheSettings()[key];
+      }
+    }
+    for (let key of Object.keys(new DisplaySettings())) {
+      if (this.displaySettings[key] == null) {
+        this.displaySettings[key] = new DisplaySettings()[key];
       }
     }
   }

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -20,7 +20,7 @@ import TimingGroup from "../sceneDetail/TimingGroup";
 const {getCurrentWindow, Menu, MenuItem, app} = remote;
 
 const keyMap = {
-  playPause: ['Play/Pause', 'space'],
+  playPause: ['Play/Pause (Playing)', 'space'],
   historyBack: ['Back in Time', 'left'],
   historyForward: ['Forward in Time', 'right'],
   navigateBack: ['Go Back to Scene Details', 'backspace'],
@@ -152,14 +152,14 @@ export default class Player extends React.Component {
             {this.state.isPlaying && (
               <div
                 className="PauseButton u-button u-clickable"
-                onClick={this.pause.bind(this)}>
+                onClick={this.setPlayPause.bind(this, false)}>
                 Pause
               </div>
             )}
             {!this.state.isPlaying && (
               <div
                 className="PlayButton u-button u-clickable"
-                onClick={this.play.bind(this)}>
+                onClick={this.setPlayPause.bind(this, true)}>
                 Play
               </div>
             )}
@@ -217,33 +217,37 @@ export default class Player extends React.Component {
 
     window.addEventListener('contextmenu', this.showContextMenu, false);
 
+    this.buildMenu();
+  }
+
+  buildMenu() {
     Menu.setApplicationMenu(Menu.buildFromTemplate([
       {
         label: app.getName(),
         submenu: [
-          {role: 'quit'},
+          { role: 'quit' },
         ],
       },
       {
         label: 'Edit',
         submenu: [
-          {role: 'undo'},
-          {role: 'redo'},
-          {type: 'separator'},
-          {role: 'cut'},
-          {role: 'copy'},
-          {role: 'paste'},
-          {role: 'pasteandmatchstyle'},
-          {role: 'delete'},
-          {role: 'selectall'}
+          { role: 'undo' },
+          { role: 'redo' },
+          { type: 'separator' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'pasteandmatchstyle' },
+          { role: 'delete' },
+          { role: 'selectall' }
         ]
       },
       {
         label: 'View',
         submenu: [
-          {role: 'reload'},
-          {role: 'forcereload'},
-          {role: 'toggledevtools'},
+          { role: 'reload' },
+          { role: 'forcereload' },
+          { role: 'toggledevtools' },
         ]
       },
       {
@@ -267,9 +271,7 @@ export default class Player extends React.Component {
     window.removeEventListener('contextmenu', this.showContextMenu);
   }
 
-  nop() {
-
-  }
+  nop() {}
 
   showContextMenu = () => {
     const contextMenu = new Menu();
@@ -319,10 +321,6 @@ export default class Player extends React.Component {
     contextMenu.popup({});
   };
 
-  play() {
-    this.setState({isPlaying: true, historyOffset: 0});
-  }
-
   playMain(empty: boolean) {
     this.setState({isMainLoaded: true, isEmpty: empty});
     if (!this.props.overlayScene || this.state.isOverlayLoaded) {
@@ -337,8 +335,22 @@ export default class Player extends React.Component {
     }
   }
 
+  play() {
+    this.setState({isPlaying: true, historyOffset: 0});
+  }
+
   pause() {
     this.setState({isPlaying: false});
+  }
+
+  setPlayPause(play: boolean) {
+    if (play) {
+      this.play()
+    } else {
+      this.pause()
+    }
+    keyMap.playPause = ["Play/Pause " + (play ? "(Playing)" : "(Paused)"), 'space'];
+    this.buildMenu();
   }
 
   historyBack() {
@@ -394,16 +406,22 @@ export default class Player extends React.Component {
 
   setAlwaysOnTop(alwaysOnTop: boolean){
     this.props.config.displaySettings.alwaysOnTop = alwaysOnTop;
+    keyMap.toggleAlwaysOnTop = ['Toggle Always On Top ' + (alwaysOnTop ? "(On)" : "(Off)"), 'CommandOrControl+T'];
+    this.buildMenu();
     getCurrentWindow().setAlwaysOnTop(alwaysOnTop);
   }
 
   setMenuBarVisibility(showMenu: boolean) {
     this.props.config.displaySettings.showMenu = showMenu;
+    keyMap.toggleMenuBarDisplay = ['Toggle Menu Bar ' + (showMenu ? "(On)" : "(Off)"), 'CommandOrControl+^'];
+    this.buildMenu();
     getCurrentWindow().setMenuBarVisibility(showMenu);
   }
 
   setFullscreen(fullScreen: boolean) {
     this.props.config.displaySettings.fullScreen = fullScreen;
+    keyMap.toggleFullscreen = ['Toggle Fullscreen ' + (fullScreen ? "(On)" : "(Off)"), 'CommandOrControl+F'];
+    this.buildMenu();
     getCurrentWindow().setFullScreen(fullScreen);
   }
 
@@ -425,11 +443,7 @@ export default class Player extends React.Component {
   }
 
   playPause() {
-    if (this.state.isPlaying) {
-      this.pause()
-    } else {
-      this.play()
-    }
+    this.setPlayPause(!this.state.isPlaying)
   }
 
   toggleAlwaysOnTop() {

--- a/src/renderer/components/player/Player.tsx
+++ b/src/renderer/components/player/Player.tsx
@@ -129,7 +129,10 @@ export default class Player extends React.Component {
             url={textURL(this.props.scene.textKind, this.props.scene.textSource)}/>
         )}
 
-        <div className={`u-button-row ${this.state.isPlaying ? 'u-show-on-hover-only' : ''}`}>
+        <div className={`u-button-row ${this.state.isPlaying ? 'u-show-on-hover-only' : ''}`} 
+             onMouseEnter={this.setMenuBarVisibleOnHover.bind(this)}
+             onMouseLeave={this.setMenuBarVisibleOnHover.bind(this)}
+             >
           <div className="u-button-row-right">
             {this.props.scene.audioURL && isLoaded && (
               <Sound
@@ -210,6 +213,10 @@ export default class Player extends React.Component {
   }
 
   componentDidMount() {
+    
+    this.setAlwaysOnTop(this.props.config.displaySettings.alwaysOnTop);
+    this.setMenuBarVisibility(this.props.config.displaySettings.showMenu);
+  
     window.addEventListener('contextmenu', this.showContextMenu, false);
 
     Menu.setApplicationMenu(Menu.buildFromTemplate([
@@ -408,12 +415,43 @@ export default class Player extends React.Component {
 
   alwaysOnTop() {
     const window = getCurrentWindow();
-    window.setAlwaysOnTop(!window.isAlwaysOnTop());
+    this.setAlwaysOnTop(!window.isAlwaysOnTop());
+  }
+
+  /** Sets window.setAlwaysOnTop and strores the state */
+  setAlwaysOnTop(value:boolean){
+    const window = getCurrentWindow();
+    this.props.config.displaySettings.alwaysOnTop = value;
+    window.setAlwaysOnTop(value);
   }
 
   toggleMenuBarDisplay() {
     const window = getCurrentWindow();
-    window.setMenuBarVisibility(!window.isMenuBarVisible());
+    this.setMenuBarVisibility(!this.props.config.displaySettings.showMenu);
+  }
+
+  /** Sets window.setMenuBarVisibility and stores the state */
+  setMenuBarVisibility(value: boolean) {
+    const window = getCurrentWindow();
+    this.props.config.displaySettings.showMenu = value;
+    window.setMenuBarVisibility(value);
+  }
+
+  setMenuBarVisibleOnHover(mouseEvent: MouseEvent) {
+    const window = getCurrentWindow();
+  
+    // Mouse entering button row and menu not visible - make menu visible
+    if (!window.isMenuBarVisible() && mouseEvent.type == "mouseenter" && mouseEvent.clientY > 0) {
+      window.setMenuBarVisibility(true);
+    }
+    // Mouse leaving button row going to menu keep menu visible
+    else if (mouseEvent.type == "mouseleave" && mouseEvent.clientY <= 0) {
+      window.setMenuBarVisibility(true);
+    }
+    // Mouse leaving button row not going to menu set menu per props
+    else if (mouseEvent.type == "mouseleave" && mouseEvent.clientY >= 0) {
+      window.setMenuBarVisibility(this.props.config.displaySettings.showMenu);
+    }
   }
 
   toggleFullscreen() {

--- a/src/renderer/icons/fullscreen.svg
+++ b/src/renderer/icons/fullscreen.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 298.667 298.667" style="enable-background:new 0 0 298.667 298.667;" xml:space="preserve">
+<g>
+	<g>
+		<g>
+			<polygon points="42.667,192 0,192 0,298.667 106.667,298.667 106.667,256 42.667,256 			"/>
+			<polygon points="0,106.667 42.667,106.667 42.667,42.667 106.667,42.667 106.667,0 0,0 			"/>
+			<polygon points="192,0 192,42.667 256,42.667 256,106.667 298.667,106.667 298.667,0 			"/>
+			<polygon points="256,256 192,256 192,298.667 298.667,298.667 298.667,192 256,192 			"/>
+		</g>
+	</g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/src/renderer/style.scss
+++ b/src/renderer/style.scss
@@ -250,6 +250,14 @@ a {
   background-size: 1rem 1rem;
 }
 
+.u-fullscreen {
+  cursor: pointer;
+  width: 1rem;
+  height: 1rem;
+  background: url("./icons/fullscreen.svg") no-repeat;
+  background-size: 1rem 1rem;
+}
+
 .u-show-on-hover-only {
   border-bottom: none;
   background: rgba(0, 0, 0, 0);


### PR DESCRIPTION
This PR is an attempt to persist the alwaysOnTop and menuBarVisibility states between launches of Flipflip,   In addition it also deals with activating the menu when the menu has been hidden see #129.  It does this by toggling the menu when the mouse enters the `u-button-row`

I say 'attempt' - because I am not sure if you will approve of using the Config class for storing the states, and the toggling of the menu on entry to the u-button-row is a clunky.

F3