### PR TITLE
Fix potential nullref error causing lockup on load

### DIFF
--- a/src/renderer/components/Meta.tsx
+++ b/src/renderer/components/Meta.tsx
@@ -238,7 +238,7 @@ export default class Meta extends React.Component {
               tutorial={this.state.tutorial}
               onUpdateScene={a(actions.updateScene)}
               goBack={a(actions.endPlaySceneFromLibrary)}
-              tags={actions.getLibrarySource(this.state).tags}
+              tags={actions.getLibrarySource(this.state)?.tags}
               allTags={this.state.tags}
               toggleTag={a(actions.toggleTag)}
               navigateTagging={a(actions.navigateDisplayedLibrary)}


### PR DESCRIPTION
When starting FlipFlip with the last viewed scene being a library temp scene, getLibrarySource will return null. This causes an error that FlipFlip does not recover from, when it attempts to access null.tags.

Making this access null conditional resolves this entirely.