### PR TITLE
QOL Updates for bdsmlr URLs

### DIFF
--- a/src/renderer/components/player/SourceScraper.tsx
+++ b/src/renderer/components/player/SourceScraper.tsx
@@ -1240,7 +1240,7 @@ function loadEHentai(systemMessage: Function, config: Config, source: LibrarySou
 }
 
 function loadBDSMlr(systemMessage: Function, config: Config, source: LibrarySource, filter: string, helpers: {next: any, count: number}): CancelablePromise {
-  const url = source.url;
+  const url = getFileGroup(source.url);
   return new CancelablePromise((resolve) => {
     wretch(url + "/rss?page=" + (helpers.next + 1))
       .get()

--- a/src/renderer/components/player/SourceScraper.tsx
+++ b/src/renderer/components/player/SourceScraper.tsx
@@ -1240,7 +1240,10 @@ function loadEHentai(systemMessage: Function, config: Config, source: LibrarySou
 }
 
 function loadBDSMlr(systemMessage: Function, config: Config, source: LibrarySource, filter: string, helpers: {next: any, count: number}): CancelablePromise {
-  const url = getFileGroup(source.url);
+  let url = source.url;
+  if (url.endsWith("/rss")) {
+    url = url.substring(0, url.indexOf("/rss"))
+  }
   return new CancelablePromise((resolve) => {
     wretch(url + "/rss?page=" + (helpers.next + 1))
       .get()

--- a/src/renderer/data/utils.ts
+++ b/src/renderer/data/utils.ts
@@ -171,7 +171,7 @@ export function getSourceType(url: string): string {
     return ST.gelbooru1;
   } else if (/^https?:\/\/(www\.)?e-hentai\.org\/g\//.exec(url) != null) {
     return ST.ehentai;
-  } else if (/^https?:\/\/[^.]*\.bdsmlr\.com/.exec(url) != null) {
+  } else if (/^https?:\/\/[^.]*\.bdsmlr\.com[^.]*/.exec(url) != null) {
     return ST.bdsmlr;
   } else if (/(^https?:\/\/)|(\.txt$)/.exec(url) != null) { // Arbitrary URL, assume image list
     return ST.list;
@@ -285,7 +285,13 @@ export function getFileGroup(url: string) {
       }
       let name = url.substring(0, url.lastIndexOf(sep));
       return name.substring(name.lastIndexOf(sep)+1);
-
+    case ST.bdsmlr:
+      //We already add "/rss" to bdsmlr URLs
+      if (url.endsWith("/")) {
+        return url.substring(0, url.length - 1);
+      } else if (url.endsWith("/rss")) {
+        return url.substring(0, url.indexOf("/rss"))
+      }
   }
 }
 

--- a/src/renderer/data/utils.ts
+++ b/src/renderer/data/utils.ts
@@ -171,7 +171,7 @@ export function getSourceType(url: string): string {
     return ST.gelbooru1;
   } else if (/^https?:\/\/(www\.)?e-hentai\.org\/g\//.exec(url) != null) {
     return ST.ehentai;
-  } else if (/^https?:\/\/[^.]*\.bdsmlr\.com[^.]*/.exec(url) != null) {
+  } else if (/^https?:\/\/[^.]*\.bdsmlr\.com/.exec(url) != null) {
     return ST.bdsmlr;
   } else if (/(^https?:\/\/)|(\.txt$)/.exec(url) != null) { // Arbitrary URL, assume image list
     return ST.list;
@@ -286,12 +286,10 @@ export function getFileGroup(url: string) {
       let name = url.substring(0, url.lastIndexOf(sep));
       return name.substring(name.lastIndexOf(sep)+1);
     case ST.bdsmlr:
-      //We already add "/rss" to bdsmlr URLs
-      if (url.endsWith("/")) {
-        return url.substring(0, url.length - 1);
-      } else if (url.endsWith("/rss")) {
-        return url.substring(0, url.indexOf("/rss"))
-      }
+      let bdsmlrID = url.replace(/https?:\/\//, "");
+      bdsmlrID = bdsmlrID.replace(/\/rss/, "");
+      bdsmlrID = bdsmlrID.replace(/\.bdsmlr\.com\/?/, "");
+      return bdsmlrID;
   }
 }
 


### PR DESCRIPTION
A basic quality of life update to account for the fact that FlipFlip appends `/rss` to the end of bdsmlr urls, which makes urls like `https://somecoolblog.bdsmlr.com/` and `https://somecoolblog.bdsmlr.com/rss` not work. 

Wasn't quite sure where the logic for this should live, so definitely open to feedback if it should be elsewhere. Mostly I was having fun getting set up and poking around the code base, but feel free to use if it's helpful!