### PR TITLE
Allow Gif Option to respect Hydrus sources

### DIFF
--- a/src/renderer/components/configGroups/SceneOptionCard.tsx
+++ b/src/renderer/components/configGroups/SceneOptionCard.tsx
@@ -683,7 +683,8 @@ class SceneOptionCard extends React.Component {
     if (id === "0") return "None";
     if (id === "-1") return "Random";
     if (id.startsWith('999')) {
-      return this.props.allSceneGrids.find((s) => s.id.toString() == id.replace('999', '')).name;
+      // TODO Remove grid from overlays/next when deleted
+      return this.props.allSceneGrids.find((s) => s.id.toString() == id.replace('999', ''))?.name;
     }
     return this.props.allScenes.find((s) => s.id.toString() === id).name;
   }

--- a/src/renderer/components/player/Scrapers.ts
+++ b/src/renderer/components/player/Scrapers.ts
@@ -1980,7 +1980,7 @@ export const loadHydrus = (allURLs: Map<string, Array<string>>, config: Config, 
               (filter == IF.stills || filter == IF.images) && isImage(metadata.ext, true) ||
               (filter == IF.animated && metadata.ext.toLowerCase().endsWith('.gif') || isVideo(metadata.ext, true)) ||
               (filter == IF.videos && isVideo(metadata.ext, true))) {
-              images.push(hydrusURL + "/get_files/file?file_id=" + metadata.file_id + "&Hydrus-Client-API-Access-Key=" + apiKey);
+              images.push(hydrusURL + "/get_files/file?file_id=" + metadata.file_id + "&Hydrus-Client-API-Access-Key=" + apiKey + "&ext=" + metadata.ext);
             }
           }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -11,7 +11,7 @@
     <!-- Font Icons -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
 
-    <meta http-equiv="Content-Security-Policy" content="frame-src https://www.imagefap.com"/>
+    <meta http-equiv="Content-Security-Policy" content="frame-src https://www.imagefap.com http://www.imagefap.com"/>
 </head>
 
 <body>


### PR DESCRIPTION
This is a rebased version of #265

> Issue: When playing a Scene from certain sources, gif images from that source don't have the Scene's "GIF Options" selection applied to them. So, for instance, if the Scene's timing is a Constant 1000ms and the Scene's "GIF Options" is set to "Play Full", gifs from the affected sources will always only play for 1000ms, regardless of their actual duration. (Reported in Issue #266 )
>
>Technical background:
This issue affects all sources who's file URLs do not include an extension in the URL - namely, all sources where the file URLs are actually an API request. I found it when testing other things for a Hydrus source, from which FlipFlip gather's file URLs that look like this:
http://localhost:45869/get_files/file?file_id=4674&Hydrus-Client-API-Access-Key=somelongcoolkey
>
>It's fairly common for API endpoints that fetch files to return the file directly (rather than returning a direct link to the file), but a side-effect of this is that the file's extension or filename isn't actually part of the URL itself. I'm admittedly not familiar with the file URL format for other sources, but it wouldn't surprise me if this issue also affects some current sources or sources that might be added in the future.
>
>Solution:
This is probably the simplest solution - just removing the extension check from this if statement in ImagePlayer, and instead relying on gifInfo() to determine if the image is animated or not. From my testing of it, it seems to work well, and doesn't cause any issues for still images! (thanks to processImage already having checks for that)
>
>One consideration here, though - I'm unsure how CPU/memory/time-expensive the gifInfo() function call is when called on non-gif files, but if it's expensive enough, it's possible that calling it on all image files may cause a performance decrease. I didn't see any in my testing, but it's worth keeping in mind. If it does, I listed some potential alternative approaches to this problem in the section below.
>
>Potential Alternate Solutions
>
>Rather than checking the URL extension, check the response headers from the response.get() call for a content-type header that equals image/gif
Downside: Not all APIs may return a content-type header, unfortunately.
Do something clever with creating file URLs from Hydrus sources
If we could add image 'objects' rather than string URLs to be parsed by ImagePlayer, we could add the metadata information that we have access to when parsing file URLs from the response we get from the /file_metadata API call. Downside would be the major refactor involved in switching over from strings to objects there.
We could also do something hacky like add the extension we find in the file metadata to the end of the Hydrus file URLs, like this: http://localhost:45869/get_files/file?file_id=4674&Hydrus-Client-API-Access-Key=somelongcoolkey&.gif. Good news is that URL will return the same thing as a normal file URL! Bad news is that it's, well, ugly, and also it would have to be a custom implementation for every source that has or will have this problem.