### PR TITLE
Issue #262 - Preserve Additional Query Params When Using Hydrus URL Source

### DIFF
--- a/src/renderer/components/player/Scrapers.ts
+++ b/src/renderer/components/player/Scrapers.ts
@@ -1874,9 +1874,6 @@ export const loadHydrus = (allURLs: Map<string, Array<string>>, config: Config, 
       });
     }
 
-    const tagsRegex = /tags=([^&]*)&?.*$/.exec(source.url);
-    let noTags = tagsRegex == null || tagsRegex.length <= 1;
-
     const getSessionKey = () => {
       wretch(hydrusURL + "/session_key")
         .headers({"Hydrus-Client-API-Access-Key": apiKey})
@@ -1912,7 +1909,7 @@ export const loadHydrus = (allURLs: Map<string, Array<string>>, config: Config, 
 
     let pages = 0;
     const search = () => {
-      const url = noTags ? hydrusURL + "/get_files/search_files" : hydrusURL + "/get_files/search_files?tags=" + tagsRegex[1];
+      const url = source.url;
       wretch(url)
         .headers({"Hydrus-Client-API-Session-Key": sessionKey})
         .get()


### PR DESCRIPTION
This is a rebased version of #264

> This one's pretty straightforward - rather than use a regex to get the tags, we just use the Hydrus URL configured in the source directly. Since there's already a check to make sure that the source URL starts with the URL preserved in the Hydrus auth, we can be confident that it's a Hydrus URL either way.
>
> This will allow Hydrus sources configured with the system_inbox or system_archive query parameters to respect those parameters (as mentioned in issue #262 ), as well as make room for future query parameters the Hydrus dev may add to that endpoint over time.