### PR TITLE
Fix Hydrus performance

### DIFF
--- a/src/renderer/components/player/Scrapers.ts
+++ b/src/renderer/components/player/Scrapers.ts
@@ -2678,7 +2678,7 @@ export const loadHydrus = (allURLs: Map<string, Array<string>>, allPosts: Map<st
     let images = Array<string>();
     const getFileMetadata = (fileIDs: Array<number>, page: number) => {
       const pageIDs = fileIDs.slice(page*chunk, (page+1)*chunk);
-      wretch(hydrusURL + "/get_files/file_metadata?file_ids=[" + pageIDs.toString() + "]")
+      wretch(hydrusURL + "/get_files/file_metadata?only_return_basic_information=true&include_services_object=false&file_ids=[" + pageIDs.toString() + "]")
         .headers({"Hydrus-Client-API-Access-Key": apiKey})
         .get()
         .setTimeout(15000)


### PR DESCRIPTION
https://hydrusnetwork.github.io/hydrus/developer_api.html#get_files_file_metadata by default includes a lot of things that flipflip doesn't use.
On a large Hydrus database and a broad search query this causes significant slowdown.
A couple of arguments reduces the amount of data Hydrus has to collect for each image to bare minimum.